### PR TITLE
Enable scalacOptions for warnings, fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 sudo: true #use legacy travis infra which works better
 scala:
-   - 2.11.6
+   - 2.11.7
 jdk:
    - oraclejdk8
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-
 organization in ThisBuild := "com.iheart"
 
 version in ThisBuild := "1.0.0-" + Versions.releaseType
@@ -12,6 +11,5 @@ resolvers ++= Dependencies.resolvers
 libraryDependencies ++= Dependencies.akka ++
                         Dependencies.test
 
-
-
+scalacOptions ++= List("-feature", "-deprecation", "-unchecked", "-Xlint")
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -2,7 +2,7 @@ object Versions {
 
   val releaseType = "SNAPSHOT"
 
-  val scala       = "2.11.6"
+  val scala       = "2.11.7"
   val akka        = "2.4-M3"
   val specs2      = "3.0"
 

--- a/src/main/scala/com/iheart/workpipeline/akka/patterns/WorkPipeline.scala
+++ b/src/main/scala/com/iheart/workpipeline/akka/patterns/WorkPipeline.scala
@@ -32,7 +32,7 @@ trait WorkPipeline extends Actor {
     context.actorOf(AutoScaling.default(queue, processor, s), name + "-auto-scaler" )
   }
 
-  def receive = ({
+  def receive: Receive = ({
     case ShutdownGracefully(reportBack, timeout) ⇒ processor ! QueueProcessor.Shutdown(reportBack, timeout, true)
     case Terminated(`processor`) ⇒ context stop self
   }: Receive) orElse extraReceive

--- a/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/AutoScaling.scala
+++ b/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/AutoScaling.scala
@@ -12,6 +12,7 @@ import com.iheart.workpipeline.akka.patterns.queue.Worker.{Working, WorkerStatus
 
 import scala.concurrent.duration._
 import scala.util.Random
+import scala.language.implicitConversions
 
 trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
   val queue: QueueRef

--- a/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/Queue.scala
+++ b/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/Queue.scala
@@ -62,7 +62,7 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
   }
 
   private def finish(status: QueueStatus, withMessage: String): Unit = {
-    log.info(withMessage + "- ${status.countOfWorkSent} work sent.")
+    log.info(withMessage + s"- ${status.countOfWorkSent} work sent.")
     status.queuedWorkers.foreach( _ ! NoWorkLeft)
     context stop self
   }
@@ -216,7 +216,7 @@ object Queue {
   trait QueueDispatchInfo {
     def avgDispatchDurationLowerBound: Option[Duration]
   }
-  private[queue] case class QueueStatus(
+  protected[queue] case class QueueStatus(
                                     workBuffer: ScalaQueue[Work] = ScalaQueue.empty,
                                     queuedWorkers: ScalaQueue[ActorRef] = ScalaQueue.empty,
                                     countOfWorkSent: Int = 0,

--- a/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/QueueProcessor.scala
+++ b/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/QueueProcessor.scala
@@ -17,8 +17,8 @@ trait QueueProcessor extends Actor with ActorLogging with MessageScheduler {
   def settings: ProcessingWorkerPoolSettings
 
   override val supervisorStrategy =
-    OneForOneStrategy(maxNrOfRetries = 10, withinTimeRange = 1 minute) {
-      case _: Exception                => Restart
+    OneForOneStrategy(maxNrOfRetries = 10, withinTimeRange = 1.minute) {
+      case _: Exception => Restart
     }
 
   def workerProp(queueRef: QueueRef, delegateeProps: Props): Props

--- a/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/Worker.scala
+++ b/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/Worker.scala
@@ -21,7 +21,7 @@ trait Worker extends Actor with ActorLogging with MessageScheduler {
   protected def monitor: ActorRef = context.parent
 
   def receive = idle()
-  
+
   def resultHistoryLength: Int
 
   //hate to have a var here, but this field avoid having to pass this history all over the places.
@@ -149,10 +149,10 @@ trait Worker extends Actor with ActorLogging with MessageScheduler {
 
 
   protected def resultChecker: ResultChecker
-  
+
   protected def holdOnGettingMoreWork: Option[FiniteDuration]
 
-  private case class Outstanding(work: Work, timeoutHandle: Cancellable, retried: Int = 0) {
+  protected case class Outstanding(work: Work, timeoutHandle: Cancellable, retried: Int = 0) {
     def done(result: Any): Unit = {
       cancel()
       reportResult(result)

--- a/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/package.scala
+++ b/src/main/scala/com/iheart/workpipeline/akka/patterns/queue/package.scala
@@ -8,9 +8,9 @@ package object queue {
   type QueueProcessorRef = ActorRef
   type WorkerRef = ActorRef
   type ResultChecker = PartialFunction[Any, Either[String, Any]]
+}
 
-
-
+package queue {
   private[queue] case class Work(messageToDelegatee: Any, settings: WorkSettings = WorkSettings())
 
   private[queue] case class Rejected(work: Work, reason: String)


### PR DESCRIPTION
Fixes warnings:
- implicit conversion method durationToJDuration should be enabled
- a type was inferred to be `Any`; this may indicate a programming error.
  - related to `({...} : Receive) orElse extraReceive`. [Resolved](https://issues.scala-lang.org/browse/SI-8861) in scala 2.11.7
- possible missing interpolator: detected an interpolated expression 
  - `log.info(withMessage + "- ${status.countOfWorkSent} work sent."`
- postfix operator minute should be enabled by making the implicit value `scala.language.postfixOps` visible.
- it is not recommended to define classes/objects inside of package objects. If possible, define class Work in package queue instead.
- various references to methods accepting private classes (changed them to protected)
