### PR TITLE
Autoformat, Rename statsD config key to statsd

### DIFF
--- a/src/main/scala/com/iheart/util/ConfigWrapper.scala
+++ b/src/main/scala/com/iheart/util/ConfigWrapper.scala
@@ -22,36 +22,36 @@ class ConfigWrapper(underlying: Config) {
   def getOption[T: TypeTag](path: String): Option[T] = getWithMode(path, Mode.optionMode)
 
   /** Convenience method for getting a value, with a fallback if path not found */
-  def getOrElse[T: TypeTag](path: String, fallback: => T): T = getOption[T](path).getOrElse(fallback)
+  def getOrElse[T: TypeTag](path: String, fallback: ⇒ T): T = getOption[T](path).getOrElse(fallback)
 
   protected def getWithMode[T: TypeTag](path: String, mode: Mode): mode.Type[T] = typeOf[T] match {
-    case t if t =:= typeOf[Boolean] =>
+    case t if t =:= typeOf[Boolean] ⇒
       getValue(path, mode, _.getBoolean)
-    case t if t =:= typeOf[List[Boolean]] =>
-      getValue(path, mode, c => c.getBooleanList(_).asScala.map(_ == true).toList)
+    case t if t =:= typeOf[List[Boolean]] ⇒
+      getValue(path, mode, c ⇒ c.getBooleanList(_).asScala.map(_ == true).toList)
 
-    case t if t =:= typeOf[Double] =>
+    case t if t =:= typeOf[Double] ⇒
       getValue(path, mode, _.getDouble)
-    case t if t =:= typeOf[List[Double]] =>
-      getValue(path, mode, c => c.getDoubleList(_).asScala.map(_.toDouble).toList)
+    case t if t =:= typeOf[List[Double]] ⇒
+      getValue(path, mode, c ⇒ c.getDoubleList(_).asScala.map(_.toDouble).toList)
 
-    case t if t =:= typeOf[Int] =>
+    case t if t =:= typeOf[Int] ⇒
       getValue(path, mode, _.getInt)
-    case t if t =:= typeOf[List[Int]] =>
-      getValue(path, mode, c => c.getIntList(_).asScala.map(_.toInt).toList)
+    case t if t =:= typeOf[List[Int]] ⇒
+      getValue(path, mode, c ⇒ c.getIntList(_).asScala.map(_.toInt).toList)
 
-    case t if t =:= typeOf[String] =>
+    case t if t =:= typeOf[String] ⇒
       getValue(path, mode, _.getString)
-    case t if t =:= typeOf[List[String]] =>
-      getValue(path, mode, c => c.getStringList(_).asScala.toList)
+    case t if t =:= typeOf[List[String]] ⇒
+      getValue(path, mode, c ⇒ c.getStringList(_).asScala.toList)
 
-    case t if t =:= typeOf[Config] =>
+    case t if t =:= typeOf[Config] ⇒
       getValue(path, mode, _.getConfig)
 
-    case t => throw new MatchError(s"Unsupported type `${t.typeSymbol.fullName}` for ConfigWrapper.get")
+    case t ⇒ throw new MatchError(s"Unsupported type `${t.typeSymbol.fullName}` for ConfigWrapper.get")
   }
 
-  protected def getValue[T](path: String, mode: Mode, f: Config => String => Any): mode.Type[T] =
+  protected def getValue[T](path: String, mode: Mode, f: Config ⇒ String ⇒ Any): mode.Type[T] =
     mode.wrapException[T, ConfigException.Missing] {
       if (underlying.hasPath(path)) {
         f(underlying)(path).asInstanceOf[T]

--- a/src/main/scala/com/iheart/workpipeline/akka/helpers/MessageScheduler.scala
+++ b/src/main/scala/com/iheart/workpipeline/akka/helpers/MessageScheduler.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration.FiniteDuration
 
 trait MessageScheduler {
 
-  this: Actor with ActorLogging =>
+  this: Actor with ActorLogging ⇒
 
   def delayedMsg(delay: FiniteDuration, msg: Any, receiver: ActorRef = self): Cancellable = {
     import context.dispatcher

--- a/src/main/scala/com/iheart/workpipeline/collection/FiniteCollection.scala
+++ b/src/main/scala/com/iheart/workpipeline/collection/FiniteCollection.scala
@@ -4,7 +4,7 @@ object FiniteCollection {
 
   implicit class FiniteQueue[A](val self: Vector[A]) extends AnyVal {
 
-    def enqueueFinite[B >: A](elem: => B, maxSize: Int): Vector[B] = {
+    def enqueueFinite[B >: A](elem: ⇒ B, maxSize: Int): Vector[B] = {
       if (maxSize > 0) {
         val ret = self :+ elem
         if (ret.size > maxSize) ret.takeRight(maxSize) else ret
@@ -15,7 +15,7 @@ object FiniteCollection {
       if (self.isEmpty) None else Some((self.head, self.tail))
     }
 
-    def takeRightWhile(p: A => Boolean): Vector[A] = {
+    def takeRightWhile(p: A ⇒ Boolean): Vector[A] = {
       var result = Vector.empty[A]
       val iter = self.reverseIterator
       while (iter.hasNext) {

--- a/src/main/scala/com/iheart/workpipeline/metrics/MetricsCollector.scala
+++ b/src/main/scala/com/iheart/workpipeline/metrics/MetricsCollector.scala
@@ -20,9 +20,9 @@ object MetricsCollector {
     fromConfig(pipelineName, metricsConfig)
   }
 
-  /** If statsD config exists, create StatsD, otherwise NoOp */
+  /** If statsd config exists, create StatsD, otherwise NoOp */
   def fromConfig(pipelineName: String, config: Config)(implicit system: ActorSystem): MetricsCollector = {
-    config.getOption[Config]("statsD").fold[MetricsCollector](NoOpMetricsCollector) { statsDConf ⇒
+    config.getOption[Config]("statsd").fold[MetricsCollector](NoOpMetricsCollector) { statsDConf ⇒
       StatsDMetricsCollector.fromConfig(pipelineName, statsDConf)
     }
   }

--- a/src/main/scala/com/iheart/workpipeline/metrics/MetricsCollector.scala
+++ b/src/main/scala/com/iheart/workpipeline/metrics/MetricsCollector.scala
@@ -22,7 +22,7 @@ object MetricsCollector {
 
   /** If statsD config exists, create StatsD, otherwise NoOp */
   def fromConfig(pipelineName: String, config: Config)(implicit system: ActorSystem): MetricsCollector = {
-    config.getOption[Config]("statsD").fold[MetricsCollector](NoOpMetricsCollector) { statsDConf =>
+    config.getOption[Config]("statsD").fold[MetricsCollector](NoOpMetricsCollector) { statsDConf ⇒
       StatsDMetricsCollector.fromConfig(pipelineName, statsDConf)
     }
   }

--- a/src/main/scala/com/iheart/workpipeline/metrics/StatsDClient.scala
+++ b/src/main/scala/com/iheart/workpipeline/metrics/StatsDClient.scala
@@ -46,13 +46,13 @@ import akka.actor._
  * @param defaultSampleRate Default sample rate to use for metrics, if unspecified
  */
 class StatsDClient(
-    context: ActorRefFactory,
-    host: String,
-    port: Int,
-    prefix: String = "",
-    multiMetrics: Boolean = true,
-    packetBufferSize: Int = 1024,
-    defaultSampleRate: Double = 1.0
+  context:           ActorRefFactory,
+  host:              String,
+  port:              Int,
+  prefix:            String          = "",
+  multiMetrics:      Boolean         = true,
+  packetBufferSize:  Int             = 1024,
+  defaultSampleRate: Double          = 1.0
 ) {
 
   private val rand = new Random()
@@ -151,10 +151,10 @@ private case class SendStat(stat: String)
  * @param packetBufferSize If multiMetrics is true, this is the max buffer size before sending the UDP packet
  */
 private class StatsDActor(
-  host: String,
-    port: Int,
-    multiMetrics: Boolean,
-    packetBufferSize: Int
+  host:             String,
+  port:             Int,
+  multiMetrics:     Boolean,
+  packetBufferSize: Int
 ) extends Actor {
 
   private val log = LoggerFactory.getLogger(getClass())
@@ -165,8 +165,8 @@ private class StatsDActor(
   private val channel = DatagramChannel.open()
 
   def receive = {
-    case msg: SendStat => doSend(msg.stat)
-    case _ => log.error("Unknown message")
+    case msg: SendStat ⇒ doSend(msg.stat)
+    case _             ⇒ log.error("Unknown message")
   }
 
   override def postStop() = {
@@ -204,7 +204,7 @@ private class StatsDActor(
       }
 
     } catch {
-      case e: IOException => {
+      case e: IOException ⇒ {
         log.error("Could not send stat {} to host {}:{}", sendBuffer.toString, address.getHostName(), address.getPort().toString, e)
       }
     }
@@ -231,7 +231,7 @@ private class StatsDActor(
       }
 
     } catch {
-      case e: IOException => {
+      case e: IOException ⇒ {
         log.error("Could not send stat {} to host {}:{}", sendBuffer.toString, address.getHostName(), address.getPort().toString, e)
       }
     }

--- a/src/main/scala/com/iheart/workpipeline/metrics/StatsDMetricsCollector.scala
+++ b/src/main/scala/com/iheart/workpipeline/metrics/StatsDMetricsCollector.scala
@@ -13,11 +13,11 @@ import com.iheart.util.ConfigWrapper.ImplicitConfigWrapper
  * @param statusSampleRate sample rate for gauged events (PoolSize, WorkQueueLength, etc)
  */
 class StatsDMetricsCollector(
-  statsd: StatsDClient,
-  eventSampleRate: Double,
+  statsd:           StatsDClient,
+  eventSampleRate:  Double,
   statusSampleRate: Double
 )(implicit system: ActorSystem)
-    extends MetricsCollector {
+  extends MetricsCollector {
 
   /**
    * Auxilliary constructor that creates a StatsDClient from params
@@ -29,10 +29,10 @@ class StatsDMetricsCollector(
    * @param statusSampleRate sample rate for gauged events
    */
   def this(
-    prefix: String,
-    host: String,
-    port: Int = 8125,
-    eventSampleRate: Double = 1.0,
+    prefix:           String,
+    host:             String,
+    port:             Int    = 8125,
+    eventSampleRate:  Double = 1.0,
     statusSampleRate: Double = 1.0
   )(implicit system: ActorSystem) =
     this(new StatsDClient(system, host, port, prefix = prefix), eventSampleRate, statusSampleRate)
@@ -51,26 +51,26 @@ class StatsDMetricsCollector(
   val failureSampleRate: Double = 1.0
 
   def send(metric: Metric): Unit = metric match {
-    case WorkEnqueued => increment("queue.enqueued")
-    case EnqueueRejected => increment("queue.enqueueRejected")
-    case WorkCompleted => increment("work.completed")
-    case WorkFailed => increment("work.failed", failureSampleRate)
-    case WorkTimedOut => increment("work.timedOut")
-    case CircuitBreakerOpened => increment("queue.circuitBreakerOpened")
+    case WorkEnqueued         ⇒ increment("queue.enqueued")
+    case EnqueueRejected      ⇒ increment("queue.enqueueRejected")
+    case WorkCompleted        ⇒ increment("work.completed")
+    case WorkFailed           ⇒ increment("work.failed", failureSampleRate)
+    case WorkTimedOut         ⇒ increment("work.timedOut")
+    case CircuitBreakerOpened ⇒ increment("queue.circuitBreakerOpened")
 
-    case PoolSize(size) =>
+    case PoolSize(size) ⇒
       gauge("pool.size", size)
 
-    case PoolUtilized(numWorkers) =>
+    case PoolUtilized(numWorkers) ⇒
       gauge("pool.utilized", numWorkers)
 
-    case DispatchWait(duration) =>
+    case DispatchWait(duration) ⇒
       statsd.timing("queue.waitTime", duration.toMillis.toInt, eventSampleRate)
 
-    case WorkQueueLength(length) =>
+    case WorkQueueLength(length) ⇒
       gauge("queue.length", length)
 
-    case WorkQueueMaxLength(length) =>
+    case WorkQueueMaxLength(length) ⇒
       gauge("queue.maxLength", length)
   }
 }

--- a/src/test/scala/com/iheart/workpipeline/akka/patterns/queue/QueueSpec.scala
+++ b/src/test/scala/com/iheart/workpipeline/akka/patterns/queue/QueueSpec.scala
@@ -191,7 +191,8 @@ class CircuitBreakerSpec extends SpecWithActorSystem {
 
     "worker report to metrics after consecutive errors" in new MetricCollectorScope() {
       val queue = defaultQueue()
-      system.actorOf(queueProcessorWithCBProps(queue,
+      system.actorOf(queueProcessorWithCBProps(
+        queue,
         CircuitBreakerSettings(historyLength = 2, closeDuration = 300.milliseconds)
       ))
 
@@ -404,12 +405,11 @@ class QueueScope(implicit system: ActorSystem) extends ScopeWithQueue {
     )
 }
 
-
 class MetricCollectorScope(implicit system: ActorSystem) extends QueueScope {
   @volatile
   var receivedMetrics: List[Metric] = Nil
 
-  override val metricsCollector : MetricsCollector = new MetricsCollector {
+  override val metricsCollector: MetricsCollector = new MetricsCollector {
     def send(metric: Metric): Unit = receivedMetrics = metric :: receivedMetrics
   }
 

--- a/src/test/scala/com/iheart/workpipeline/akka/patterns/queue/QueueWithBackPressure.scala
+++ b/src/test/scala/com/iheart/workpipeline/akka/patterns/queue/QueueWithBackPressure.scala
@@ -69,7 +69,7 @@ class QueueWithBackPressureSpec extends SpecWithActorSystem {
       thresholdForExpectedWaitTime = 5.minutes
     ))).underlyingActor
 
-    def status(ps: (Int, Int, LocalDateTime)*): QueueStatus = QueueStatus(bufferHistory = ps.map { case (dispatched, size, time) => BufferHistoryEntry(dispatched, size, time) }.toVector)
+    def status(ps: (Int, Int, LocalDateTime)*): QueueStatus = QueueStatus(bufferHistory = ps.map { case (dispatched, size, time) ⇒ BufferHistoryEntry(dispatched, size, time) }.toVector)
 
     "return false if there is no entries" >> {
       q.isOverCapacity(status()) must beFalse
@@ -156,7 +156,7 @@ class QueueWithBackPressureSpec extends SpecWithActorSystem {
       )
       val start = System.nanoTime()
       val sampleSize = 10000
-      (1 to sampleSize).foreach(_ =>
+      (1 to sampleSize).foreach(_ ⇒
         q.isOverCapacity(hist))
 
       val duration = (System.nanoTime() - start) / 1000

--- a/src/test/scala/com/iheart/workpipeline/akka/patterns/queue/TestUtils.scala
+++ b/src/test/scala/com/iheart/workpipeline/akka/patterns/queue/TestUtils.scala
@@ -14,7 +14,7 @@ object TestUtils {
 
   class Wrapper(prob: ActorRef) extends Actor {
     def receive = {
-      case m => prob forward m
+      case m ⇒ prob forward m
     }
   }
 
@@ -23,13 +23,13 @@ object TestUtils {
   }
 
   val resultChecker: ResultChecker = {
-    case MessageProcessed(msg) => Right(msg)
-    case m => Left(s"unrecognized message received by resultChecker: $m (${m.getClass})")
+    case MessageProcessed(msg) ⇒ Right(msg)
+    case m                     ⇒ Left(s"unrecognized message received by resultChecker: $m (${m.getClass})")
   }
 
   def iteratorQueueProps(
-    iterator: Iterator[String],
-    workSetting: WorkSettings = WorkSettings(),
+    iterator:         Iterator[String],
+    workSetting:      WorkSettings     = WorkSettings(),
     metricsCollector: MetricsCollector = NoOpMetricsCollector
   ): Props =
     Queue.ofIterator(iterator.map(DelegateeMessage(_)), workSetting, metricsCollector)
@@ -41,9 +41,9 @@ object TestUtils {
     val delegateeProps = Wrapper.props(delegatee.ref)
 
     def defaultProcessorProps(
-      queue: QueueRef,
-      settings: ProcessingWorkerPoolSettings = ProcessingWorkerPoolSettings(startingPoolSize = 1),
-      metricsCollector: MetricsCollector = NoOpMetricsCollector
+      queue:            QueueRef,
+      settings:         ProcessingWorkerPoolSettings = ProcessingWorkerPoolSettings(startingPoolSize = 1),
+      metricsCollector: MetricsCollector             = NoOpMetricsCollector
     ) =
       QueueProcessor.default(queue, delegateeProps, settings, metricsCollector)(resultChecker)
   }


### PR DESCRIPTION
Also ran autoformatter, which somehow missed a lot of files in the last PR

the only real change is in `src/main/scala/com/iheart/workpipeline/metrics/MetricsCollector.scala` -- using "statsd" instead of "statsD" for the config key name
