### PR TITLE
removing intermediate actor from PushingDispatcher

### DIFF
--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueWithBackPressureSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueWithBackPressureSpec.scala
@@ -23,7 +23,6 @@ class QueueWithBackPressureSpec extends SpecWithActorSystem {
       waitForWorkerRegistration(q, 2)
 
       q ! Enqueue("a", self)
-      expectMsg(WorkEnqueued)
       q ! QueryStatus()
       val qs = expectMsgType[QueueStatus]
       qs.queuedWorkers.size === 1
@@ -31,7 +30,6 @@ class QueueWithBackPressureSpec extends SpecWithActorSystem {
       qs.dispatchHistory.map(_.dispatched).sum === 1
 
       q ! Enqueue("b", self)
-      expectMsg(WorkEnqueued)
       q ! QueryStatus()
       val qs2 = expectMsgType[QueueStatus]
       qs2.queuedWorkers.size === 0
@@ -40,7 +38,6 @@ class QueueWithBackPressureSpec extends SpecWithActorSystem {
       qs2.dispatchHistory.map(_.dispatched).sum === 2
 
       q ! Enqueue("c", self)
-      expectMsg(WorkEnqueued)
       q ! QueryStatus()
       val qs3 = expectMsgType[QueueStatus]
 


### PR DESCRIPTION
# What

Remove temporary intermediate `Handler` actor from being created by every message received by a `PushingDispatcher`
# Why

This intermediate actor was spawned on every message received, and then forwarded the message to the Queue.  It would then either wait for a `WorkEnqueued`, and kill itself,  or an `EnqueueRejected`, in which it would translate that to a `WorkRejected` message and send that back to the original `sender`.  It would then kill itself.
# How

So, instead of spawning this `Handler` actor on every request, the message and `sender` are sent directly to the Queue.  The Queue, in the event of accepting the work, remains the same, except it doesn't send the ack message anymore.  In  the event of a rejection, it sends the `WorkRejected` message directly to the `sender`.
# /etc

I was trying to utilize http://scalameter.github.io/ to do some microbenchmarking on this change, but am having no luck setting it up.  Logic wise, this change is pretty small, so I'm not overly concerned with introducing any issues.
