### PR TITLE
Normalize parameters / config between Dispatchers and Queues

### DIFF
--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
@@ -153,7 +153,13 @@ case class PullingDispatcher(
   sendResultsTo:    Option[ActorRef],
   resultChecker:    ResultChecker
 ) extends Dispatcher {
-  protected def queueProps = QueueOfIterator.props(iterator, settings.dispatchHistory, WorkSettings(settings.workRetry, settings.workTimeout), sendResultsTo, metricsCollector)
+  protected def queueProps = QueueOfIterator.props(
+    iterator,
+    settings.dispatchHistory,
+    WorkSettings(settings.workRetry, settings.workTimeout),
+    sendResultsTo,
+    metricsCollector
+  )
 }
 
 object PullingDispatcher {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -213,8 +213,10 @@ object Queue {
   case class RequestWork(requester: ActorRef)
 
   /**
-   * Enqueue a message. If the message is enqueued successfully, a [[kanaloa.reactive.dispatcher.queue.Queue.WorkEnqueued]] is sent to the sender if `sendAcks` is true.
-   * Any results will be sent to the `replyTo` actor.  If the work is rejected, a [[WorkRejected]] is sent to the sender, regardless of the value of `sendAcks`.
+   * Enqueue a message. If the message is enqueued successfully, a [[kanaloa.reactive.dispatcher.queue.Queue.WorkEnqueued]]
+   * is sent to the sender if `sendAcks` is true.
+   * Any results will be sent to the `replyTo` actor.  If the work is rejected, a [[WorkRejected]] is sent to the sender,
+   * regardless of the value of `sendAcks`.
    * @param workMessage The message to enqueue
    * @param sendAcks Send ack messages.  This does not control [[WorkRejected]] messages, which are sent regardless for backpressure.
    * @param sendResultsTo Actor which can optionally receive responses from downstream backends.

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -27,18 +27,19 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
 
   final def processing(status: QueueStatus): Receive =
     handleWork(status, processing) orElse {
-      case Enqueue(workMessage, replyTo, setting) ⇒
+      case Enqueue(workMessage, sendAcks, sendResultsTo) ⇒
         if (checkOverCapacity(status)) {
           log.warning("At capacity, rejecting message [{}]", workMessage)
-          replyTo.foreach(_ ! WorkRejected("Server out of capacity"))
+          sender() ! EnqueueRejected(workMessage, Queue.EnqueueRejected.OverCapacity, sendResultsTo)
           metricsCollector.send(Metric.EnqueueRejected)
         } else {
-          val newWork = Work(workMessage, setting.getOrElse(defaultWorkSettings))
+          val newWork = Work(workMessage, sendResultsTo, defaultWorkSettings)
           val newBuffer: ScalaQueue[Work] = status.workBuffer.enqueue(newWork)
           val newStatus: QueueStatus = dispatchWork(status.copy(workBuffer = newBuffer))
-
           metricsCollector.send(Metric.WorkEnqueued)
-
+          if (sendAcks) {
+            sender() ! WorkEnqueued
+          }
           context become processing(newStatus)
         }
 
@@ -58,9 +59,7 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
       finish(status, s"Queue successfully retired")
       PartialFunction.empty //doesn't matter after finish, but is required by the api.
     } else handleWork(status, retiring) orElse {
-      case Enqueue(_, replyTo, _) ⇒
-        replyTo.getOrElse(sender) ! Retiring
-
+      case Enqueue         ⇒ sender() ! Retiring
       case RetiringTimeout ⇒ finish(status, "Forcefully retire after timed out")
     }
 
@@ -172,6 +171,7 @@ class QueueOfIterator(
   private val iterator:        Iterator[_],
   val dispatchHistorySettings: DispatchHistorySettings,
   val defaultWorkSettings:     WorkSettings,
+  sendResultsTo:               Option[ActorRef]        = None,
   val metricsCollector:        MetricsCollector        = NoOpMetricsCollector
 ) extends QueueWithoutBackPressure {
   private case object EnqueueMore
@@ -179,7 +179,7 @@ class QueueOfIterator(
     def receive = {
       case EnqueueMore ⇒
         if (iterator.hasNext) {
-          context.parent ! Enqueue(iterator.next)
+          context.parent ! Enqueue(iterator.next, false, sendResultsTo)
         } else {
           log.debug("Iterator queue completes.")
           context.parent ! Retire()
@@ -202,23 +202,36 @@ object QueueOfIterator {
     iterator:                Iterator[_],
     dispatchHistorySettings: DispatchHistorySettings,
     defaultWorkSettings:     WorkSettings,
+    sendResultsTo:           Option[ActorRef]        = None,
     metricsCollector:        MetricsCollector        = NoOpMetricsCollector
   ): Props =
-    Props(new QueueOfIterator(iterator, dispatchHistorySettings, defaultWorkSettings, metricsCollector))
+    Props(new QueueOfIterator(iterator, dispatchHistorySettings, defaultWorkSettings, sendResultsTo, metricsCollector))
 }
 
 object Queue {
 
   case class RequestWork(requester: ActorRef)
 
-  case class Enqueue(workMessage: Any, replyTo: Option[ActorRef] = None, workSettings: Option[WorkSettings] = None)
-  object Enqueue {
-    def apply(workMessage: Any, replyTo: ActorRef): Enqueue = Enqueue(workMessage, Some(replyTo))
-  }
+  /**
+   * Enqueue a message. If the message is enqueued successfully, a [[kanaloa.reactive.dispatcher.queue.Queue.WorkEnqueued]] is sent to the sender if `sendAcks` is true.
+   * Any results will be sent to the `replyTo` actor.  If the work is rejected, a [[WorkRejected]] is sent to the sender, regardless of the value of `sendAcks`.
+   * @param workMessage The message to enqueue
+   * @param sendAcks Send ack messages.  This does not control [[WorkRejected]] messages, which are sent regardless for backpressure.
+   * @param sendResultsTo Actor which can optionally receive responses from downstream backends.
+   */
+  case class Enqueue(workMessage: Any, sendAcks: Boolean = false, sendResultsTo: Option[ActorRef] = None)
+
   case object WorkEnqueued
   case object Unregistered
 
   case class Unregister(worker: WorkerRef)
+
+  case class EnqueueRejected(workMessage: Any, reason: EnqueueRejected.Reason, sendResultsTo: Option[ActorRef])
+
+  object EnqueueRejected {
+    sealed trait Reason
+    case object OverCapacity extends Reason
+  }
 
   case object Retiring
   case object NoWorkLeft
@@ -267,17 +280,19 @@ object Queue {
     iterable:                Iterable[_],
     dispatchHistorySettings: DispatchHistorySettings,
     defaultWorkSetting:      WorkSettings            = WorkSettings(),
+    sendResultsTo:           Option[ActorRef]        = None,
     metricsCollector:        MetricsCollector        = NoOpMetricsCollector
   ): Props =
-    QueueOfIterator.props(iterable.iterator, dispatchHistorySettings, defaultWorkSetting, metricsCollector)
+    QueueOfIterator.props(iterable.iterator, dispatchHistorySettings, defaultWorkSetting, sendResultsTo, metricsCollector)
 
   def ofIterator(
     iterator:                Iterator[_],
     dispatchHistorySettings: DispatchHistorySettings,
     defaultWorkSetting:      WorkSettings            = WorkSettings(),
+    sendResultsTo:           Option[ActorRef]        = None,
     metricsCollector:        MetricsCollector        = NoOpMetricsCollector
   ): Props =
-    QueueOfIterator.props(iterator, dispatchHistorySettings, defaultWorkSetting, metricsCollector)
+    QueueOfIterator.props(iterator, dispatchHistorySettings, defaultWorkSetting, sendResultsTo, metricsCollector)
 
   def default(
     dispatchHistorySettings: DispatchHistorySettings = DispatchHistorySettings(),

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
@@ -189,8 +189,7 @@ trait Worker extends Actor with ActorLogging with MessageScheduler {
 
     lazy val workDescription = descriptionOf(work.messageToDelegatee)
 
-    def reportResult(result: Any): Unit = work.settings.sendResultTo.foreach(_ ! result)
-
+    def reportResult(result: Any): Unit = work.replyTo.foreach(_ ! result)
   }
 
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -15,11 +15,11 @@ package kanaloa.reactive.dispatcher {
 
 package kanaloa.reactive.dispatcher.queue {
 
-  private[queue] case class Work(messageToDelegatee: Any, settings: WorkSettings = WorkSettings())
+  private[queue] case class Work(messageToDelegatee: Any, replyTo: Option[ActorRef], settings: WorkSettings = WorkSettings())
 
   private[queue] case class Rejected(work: Work, reason: String)
 
-  case class WorkSettings(retry: Int = 0, timeout: FiniteDuration = 30.seconds, sendResultTo: Option[ActorRef] = None)
+  case class WorkSettings(retry: Int = 0, timeout: FiniteDuration = 30.seconds)
 
   case class CircuitBreakerSettings(
     closeDuration:      FiniteDuration = 3.seconds,

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
@@ -32,9 +32,9 @@ trait IntegrationSpec extends WordSpecLike with ShouldMatchers {
           tick-duration = 1ms
           ticks-per-wheel = 2
         }
-        stdout-loglevel = ${logLevel}
+        stdout-loglevel = $logLevel
 
-        loglevel = ${logLevel}
+        loglevel = $logLevel
       }
 
       kanaloa.default-dispatcher {
@@ -133,6 +133,7 @@ class PullingDispatcherIntegration extends IntegrationSpec {
       "test-pulling",
       iterator,
       backend,
+      None,
       ConfigFactory.parseString(
         s"""
           kanaloa.dispatchers.test-pulling {
@@ -222,6 +223,7 @@ class AutoScalingWithPullingIntegration extends IntegrationSpec {
       "test-pulling",
       iteratorOf(numberOfMessages),
       backend,
+      None,
       ConfigFactory.parseString(
         """
           kanaloa.dispatchers.test-pulling {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
@@ -395,7 +395,12 @@ class QueueScope(implicit system: ActorSystem) extends ScopeWithQueue {
     }
   }
 
-  def iteratorQueue(iterator: Iterator[String], workSetting: WorkSettings = WorkSettings(), sendResultsTo: Option[ActorRef] = None, historySettings: DispatchHistorySettings = DispatchHistorySettings()): QueueRef =
+  def iteratorQueue(
+    iterator:        Iterator[String],
+    workSetting:     WorkSettings            = WorkSettings(),
+    sendResultsTo:   Option[ActorRef]        = None,
+    historySettings: DispatchHistorySettings = DispatchHistorySettings()
+  ): QueueRef =
     system.actorOf(
       iteratorQueueProps(iterator, historySettings, workSetting, sendResultsTo, metricsCollector),
       "iterator-queue-" + Random.nextInt(100000)

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueWithBackPressureSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueWithBackPressureSpec.scala
@@ -22,14 +22,14 @@ class QueueWithBackPressureSpec extends SpecWithActorSystem {
 
       waitForWorkerRegistration(q, 2)
 
-      q ! Enqueue("a", self)
+      q ! Enqueue("a")
       q ! QueryStatus()
       val qs = expectMsgType[QueueStatus]
       qs.queuedWorkers.size === 1
       qs.dispatchHistory.last.queueLength === 0
       qs.dispatchHistory.map(_.dispatched).sum === 1
 
-      q ! Enqueue("b", self)
+      q ! Enqueue("b")
       q ! QueryStatus()
       val qs2 = expectMsgType[QueueStatus]
       qs2.queuedWorkers.size === 0
@@ -37,7 +37,7 @@ class QueueWithBackPressureSpec extends SpecWithActorSystem {
       qs2.dispatchHistory.last.queueLength === 0
       qs2.dispatchHistory.map(_.dispatched).sum === 2
 
-      q ! Enqueue("c", self)
+      q ! Enqueue("c")
       q ! QueryStatus()
       val qs3 = expectMsgType[QueueStatus]
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/TestUtils.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/TestUtils.scala
@@ -1,6 +1,6 @@
 package kanaloa.reactive.dispatcher.queue
 
-import akka.actor.{ActorSystem, Props}
+import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import kanaloa.reactive.dispatcher._
 import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, NoOpMetricsCollector}
@@ -20,9 +20,10 @@ object TestUtils {
     iterator:         Iterator[String],
     historySettings:  DispatchHistorySettings = DispatchHistorySettings(),
     workSetting:      WorkSettings            = WorkSettings(),
+    sendResultsTo:    Option[ActorRef]        = None,
     metricsCollector: MetricsCollector        = NoOpMetricsCollector
   ): Props =
-    Queue.ofIterator(iterator.map(DelegateeMessage(_)), historySettings, workSetting, metricsCollector)
+    Queue.ofIterator(iterator.map(DelegateeMessage(_)), historySettings, workSetting, sendResultsTo, metricsCollector)
 
   class ScopeWithQueue(implicit system: ActorSystem) extends TestKit(system) with ImplicitSender {
 


### PR DESCRIPTION
# What

This is an effort to simplify some of the interactions between Dispatchers and Queues, specifically how messages and configurations are shared between the two.  

The changes:
### Enqueue objects
- `Enqueue` and `WorkSettings` objects used to be structured as:

``` scala
case class Enqueue(workMessage: Any, replyTo: Option[ActorRef] = None, workSettings: Option[WorkSettings] = None)

case class WorkSettings(retry: Int = 0, timeout: FiniteDuration = 30.seconds, sendResultTo: Option[ActorRef] = None)
```

but have been changed to 

``` scala
case class Enqueue(workMessage: Any, sendAcks: Boolean = false, sendResultsTo: Option[ActorRef] = None)

case class WorkSettings(retry: Int = 0, timeout: FiniteDuration = 30.seconds)
```

In the older version, there existed 2 different `replyTo` parameters.  The one on `WorkSettings` was an Actor which could receive results from a `Backend` and the other one on `Enqueue` was an Actor which would receive the results of the enqueue operation itself.  

To simplify this a bit, and to preserve the ability of having a separate Actor receive downstream responses, the Enqueue operation's `replyTo` has been changed to `sendResultsTo`, and that will receive any downstream responses.  The sender of the `Enqueue` message now will be the sole receiver of any enqueue operations.  The sender will always receive rejection message to facilitate backpressure, but optionally can opt into receiving `ack` messages.  This is so that the sender can choose how to send messages to the dispatcher(ie: keep chugging until rejection, or send and wait for ack)

`WorkSettings`, which used to be specified for every Enqueue request, are now set on the Queue at creation time, and used throughout its life.  This is the same now for both `PullingDispatcher` and `PushingDispatcher`  

Since I pulled the `replyTo` off of the `WorkSettings` object, `PullingDispatcher` now has a new parameter, `sendResultsTo` which serves the same purpose.  This is set on the `Enqueue` object each time from the `PullingDispatcher`.
### EnqueueRejected / WorkRejected are back!

I killed `EnqueueRejected` in my last PR, which might have been a bit premature.  It is very much needed at the Queue level, as if a Queue rejects an `Enqueue` message, the sender needs to know what message got rejected, which is what `EnqueueRejected` has on it.  This is so that the sender can reschedule that message if need be.  Thus, `PushingDispatcher` now will listen for that `EnqueueFailed` message, and for now, just translates it to the API level `WorkRejected` message.

I added tests for the new cases.
