### PR TITLE
"Retiring" is now a EnqueueRejected reason

### DIFF
--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
@@ -36,7 +36,9 @@ trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
   }
 
   private def watchingQueueAndProcessor: Receive = {
-    case Terminated(`queue`) | Terminated(`processor`) ⇒ context stop self
+    case Terminated(`queue`) | Terminated(`processor`) | QueueProcessor.ShuttingDown ⇒ {
+      context stop self
+    }
   }
 
   private def idle: Receive = watchingQueueAndProcessor orElse {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
@@ -36,7 +36,7 @@ trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
   }
 
   private def watchingQueueAndProcessor: Receive = {
-    case Terminated(`queue`) | Terminated(`processor`) | Queue.Retiring | QueueProcessor.ShuttingDown ⇒ context stop self
+    case Terminated(`queue`) | Terminated(`processor`) ⇒ context stop self
   }
 
   private def idle: Receive = watchingQueueAndProcessor orElse {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
@@ -312,7 +312,7 @@ class DefaultQueueSpec extends SpecWithActorSystem {
     //has not "finished" with "a" (we didn't have the probe send back the finished message to the Worker)
     queue ! Retire(50.milliseconds) //give this some time to kill itself
     queue ! Enqueue("c")
-    expectMsg(Retiring)
+    expectMsg(EnqueueRejected(Enqueue("c"), Queue.EnqueueRejected.Retiring))
     //after the the Retiring state is expired, the Queue goes away
     expectTerminated(queue, 75.milliseconds)
     //TODO: need to have more tests for Queue <=> Worker messaging


### PR DESCRIPTION
Previously, when a Queue was retiring, and something tried to Enqueue some work, it would respond solely with a `Retiring` object.  This case really is identical to `EnqueueRejected`, so I made it as so.  When an `Enqueue` message is now sent to a Queue while it is shutting down, it will respond with an `EnqueueRejected` message, but with the reason set to `Retiring`.

Also, in AutoScaling, I stopped it from listening to the `Retiring` reason, since it was never sent to begin with.  I also stopped it from listening for `QueueProcessor.ShuttingDown`, mainly because it seemed redundant due to the fact it was also listening for `Terminated(queueProcessor)`, which happens after a QueueProcessor is in the `ShuttingDown` state.  

Also, this fixes #75  and #76 
