### PR TITLE
move EnqueueMore into companion

### DIFF
--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -174,7 +174,8 @@ class QueueOfIterator(
   sendResultsTo:               Option[ActorRef]        = None,
   val metricsCollector:        MetricsCollector        = NoOpMetricsCollector
 ) extends QueueWithoutBackPressure {
-  private case object EnqueueMore
+  import QueueOfIterator.EnqueueMore
+
   private class Enqueuer extends Actor {
     def receive = {
       case EnqueueMore ⇒
@@ -198,6 +199,8 @@ class QueueOfIterator(
 }
 
 object QueueOfIterator {
+  case object EnqueueMore
+
   def props(
     iterator:                Iterator[_],
     dispatchHistorySettings: DispatchHistorySettings,


### PR DESCRIPTION
`EnqueueMore` has no reason to be defined inside `QueueOfIterator`, and causes errors when `serialize-messages` is enabled, since a reference to the enclosing class `QueueOfIterator` is serialized.
