### PR TITLE
fixes to how delayBeforeNextWork is applied in a Worker

### DIFF
--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
@@ -17,6 +17,7 @@ trait Worker extends Actor with ActorLogging with MessageScheduler {
 
   protected def backend: Backend //actor who really does the work
   protected val queue: ActorRef
+  protected def resultChecker: ResultChecker
   protected def monitor: ActorRef = context.parent
 
   def receive = waitingForRoutee(None)
@@ -205,8 +206,6 @@ trait Worker extends Actor with ActorLogging with MessageScheduler {
     delayBeforeNextWork = None
     context become waitingForWork
   }
-
-  protected def resultChecker: ResultChecker
 
   protected def descriptionOf(any: Any, maxLength: Int = 100): String = {
     val msgString = any.toString


### PR DESCRIPTION
A few things in here:
- fixes #82 by removing all references to any local "workDelay" parameters, and only using the global `delayBeforeNextWork` value.  After this value is applied either to a `AskForWork` or sending a message to a Routee, it is now reset back to None.
- renamed the `starting` state to `waitingForRoutee` as it seemed a bit more accurate
- The tests I added specifically for seeing how this `delayBeforeNextWork` is applied were having trouble when I was trying to rely on `expectNoMessage(duration). I had to settle for only seeing if the`delayBeforeNextWork` was reset to None
- updated the Worker specs around Routees while Work is in flight, to assert that the Work is failed and the `replyTo` was notified of the failure.
