### PR TITLE
Centralize metric cllection fix #90

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -4,7 +4,7 @@ kanaloa {
   default-dispatcher {
     workTimeout = 1m
 
-    # how often dispather makes ajustment accordingly
+    # how often dispatcher makes adjustment accordingly
     updateInterval = 1s
 
     # When backend fails the work, the dispatcher can retry it for this many times.
@@ -70,7 +70,7 @@ kanaloa {
       chanceOfScalingDownWhenFull = 0.1
 
       # Interval between each scaling attempt
-      actionInterval = ${kanaloa.default-dispatcher.updateInterval}
+      scalingInterval = ${kanaloa.default-dispatcher.updateInterval}
 
       # If the workers have not been fully utilized (i.e. all workers are busy) for such length,
       # the autoScaling will downsize the pool.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -4,6 +4,9 @@ kanaloa {
   default-dispatcher {
     workTimeout = 1m
 
+    # how often dispather makes ajustment accordingly
+    updateInterval = 1s
+
     # When backend fails the work, the dispatcher can retry it for this many times.
     workRetry   = 0
 
@@ -44,7 +47,7 @@ kanaloa {
       maxBufferSize = 600000
 
       # Start to reject work if expected wait time is above this threshold
-      thresholdForExpectedWaitTime = 20m
+      thresholdForExpectedWaitTime = ${kanaloa.default-dispatcher.workTimeout}
     }
 
     # Length of dispatch history stored for metrics collection
@@ -67,7 +70,7 @@ kanaloa {
       chanceOfScalingDownWhenFull = 0.1
 
       # Interval between each scaling attempt
-      actionFrequency = 5s
+      actionInterval = ${kanaloa.default-dispatcher.updateInterval}
 
       # If the workers have not been fully utilized (i.e. all workers are busy) for such length,
       # the autoScaling will downsize the pool.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -10,7 +10,7 @@ kanaloa {
     workerPool {
 
       # Starting number of workers
-      startingPoolSize = 300
+      startingPoolSize = 10
 
       # Uncomment the following line for a timeout for the whole queue
       # maxProcessingTime = 1h
@@ -51,7 +51,7 @@ kanaloa {
     dispatchHistory {
 
       # Only collect recent dispatch history within the following duration
-      maxHistoryLength = 10s
+      maxHistoryLength = 30s
 
       # Dispatch history is sampled per the following duration.
       # Too granular combined with longer history length will cost more memory.

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/ApiProtocol.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/ApiProtocol.scala
@@ -9,6 +9,11 @@ object ApiProtocol {
   sealed trait Response
   sealed trait WorkException extends Response
 
+  /**
+   *
+   * @param replyTo the ref the reply will be sent to, if not set, it will use sender instead
+   * @param sender
+   */
   @SerialVersionUID(1L)
   case class QueryStatus(replyTo: Option[ActorRef] = None)(implicit sender: ActorRef) extends Request {
     def reply(msg: Any)(implicit replier: ActorRef): Unit = {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
@@ -62,7 +62,7 @@ object Dispatcher {
     backPressure:    Option[BackPressureSettings],
     autoScaling:     Option[AutoScalingSettings]
   ) {
-    val metricsCollectorSettings = MetricsCollector.MetricsCollectorSettings(updateInterval)
+    val performanceSamplerSettings = PerformanceSampler.PerformanceSamplerSettings(updateInterval)
   }
 
   val defaultBackPressureSettings = BackPressureSettings(
@@ -147,7 +147,7 @@ object PushingDispatcher {
     rootConfig: Config = ConfigFactory.load()
   )(resultChecker: ResultChecker)(implicit system: ActorSystem) = {
     val (settings, reporter) = Dispatcher.readConfig(name, rootConfig)
-    val metricsCollector = MetricsCollector(reporter, settings.metricsCollectorSettings)
+    val metricsCollector = MetricsCollector(reporter, settings.performanceSamplerSettings)
     val toBackend = implicitly[BackendAdaptor[T]]
     Props(PushingDispatcher(name, settings, toBackend(backend), metricsCollector, resultChecker)).withDeploy(Deploy.local)
   }
@@ -181,7 +181,7 @@ object PullingDispatcher {
   )(resultChecker: ResultChecker)(implicit system: ActorSystem) = {
     val (settings, reporter) = Dispatcher.readConfig(name, rootConfig)
     //for pulling dispatchers because only a new idle worker triggers a pull of work, there maybe cases where there are two idle workers but the system should be deemed as fully utilized.
-    val metricsCollector = MetricsCollector(reporter, settings.metricsCollectorSettings.copy(fullyUtilized = _ <= 2))
+    val metricsCollector = MetricsCollector(reporter, settings.performanceSamplerSettings.copy(fullyUtilized = _ <= 2))
     val toBackend = implicitly[BackendAdaptor[T]]
     Props(PullingDispatcher(name, iterator, settings, toBackend(backend), metricsCollector, sendResultsTo, resultChecker)).withDeploy(Deploy.local)
   }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
@@ -180,7 +180,8 @@ object PullingDispatcher {
     rootConfig:    Config           = ConfigFactory.load()
   )(resultChecker: ResultChecker)(implicit system: ActorSystem) = {
     val (settings, reporter) = Dispatcher.readConfig(name, rootConfig)
-    val metricsCollector = MetricsCollector(reporter, settings.metricsCollectorSettings.copy(thresholdOfIdleWorkers = 2)) //for pulling Dispatchers because only a new idle worker triggers a pull of work the threshold should be set as 2
+    //for pulling dispatchers because only a new idle worker triggers a pull of work, there maybe cases where there are two idle workers but the system should be deemed as fully utilized.
+    val metricsCollector = MetricsCollector(reporter, settings.metricsCollectorSettings.copy(fullyUtilized = _ <= 2))
     val toBackend = implicitly[BackendAdaptor[T]]
     Props(PullingDispatcher(name, iterator, settings, toBackend(backend), metricsCollector, sendResultsTo, resultChecker)).withDeploy(Deploy.local)
   }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
@@ -1,0 +1,191 @@
+package kanaloa.reactive.dispatcher
+
+import java.time.{LocalDateTime ⇒ Time}
+
+import akka.actor.{Terminated, ActorRef, Actor}
+import kanaloa.reactive.dispatcher.metrics.Metric._
+import PerformanceSampler._
+import kanaloa.reactive.dispatcher.metrics.{Metric, MetricsCollector}
+import kanaloa.util.Java8TimeExtensions._
+
+import scala.concurrent.duration._
+
+/**
+ *  Mixed-in with [[MetricsCollector]] to which all [[Metric]] are sent to.
+ *  Behind the scene it also collects performance [[Sample]] from [[WorkCompleted]] and [[WorkFailed]]
+ *  when the system is in fullyUtilized state, namely when number
+ *  of idle workers is less than [[PerformanceSamplerSettings]]
+ *  It internally publishes these [[Sample]]s as well as [[PartialUtilization]] data
+ *  which are only for internal tuning purpose, and should not be
+ *  confused with the [[Metric]] used for realtime monitoring.
+ *  It can be subscribed using [[Subscribe]] message.
+ *  It publishes [[Sample]]s and [[PartialUtilization]] number to subscribers.
+ *
+ */
+private[dispatcher] trait PerformanceSampler extends Actor {
+  self: MetricsCollector ⇒ //todo: it's using cake pattern to mixin with MetricsCollector mainly due to performance reason, there might be ways to achieve more decoupled ways without hurting performance
+
+  val settings: PerformanceSamplerSettings
+
+  var subscribers: Set[ActorRef] = Set.empty
+
+  import settings._
+
+  val scheduledSampling = {
+    import context.dispatcher
+    context.system.scheduler.schedule(
+      sampleRate,
+      sampleRate,
+      self,
+      AddSample
+    )
+  }
+
+  override def postStop(): Unit = {
+    scheduledSampling.cancel()
+    super.postStop()
+  }
+
+  def receive = partialUtilized(None)
+
+  def handleSubscriptions: Receive = {
+    case Subscribe(s) ⇒
+      subscribers += s
+      context watch s
+    case Unsubscribe(s) ⇒
+      subscribers -= s
+      context unwatch s
+    case Terminated(s) ⇒
+      subscribers -= s
+  }
+
+  def publishUtilization(idle: Int, poolSizeO: Option[Int]): Unit = {
+    poolSizeO.foreach { poolSize ⇒
+      val utilization = poolSize - idle
+      publish(PartialUtilization(utilization))
+      report(PoolUtilized(utilization))
+    }
+  }
+
+  def reportQueueLength(workLeft: Int): Unit =
+    report(WorkQueueLength(workLeft))
+
+  def fullyUtilized(s: QueueStatus): Receive = handleSubscriptions orElse {
+    case DispatchResult(idle, workLeft) ⇒
+      reportQueueLength(workLeft)
+      if (!settings.fullyUtilized(idle)) {
+        tryComplete(s)
+        publishUtilization(idle, s.poolSize)
+        context become partialUtilized(s.poolSize)
+      }
+
+    case metric: Metric ⇒
+      handle(metric) {
+        case WorkCompleted(_) | WorkFailed ⇒
+          context become fullyUtilized(s.copy(workDone = s.workDone + 1))
+
+        case PoolSize(size) ⇒
+          val sizeChanged = s.poolSize.fold(true)(_ != size)
+          if (sizeChanged) {
+            tryComplete(s)
+            context become fullyUtilized(QueueStatus(poolSize = Some(size)))
+          }
+      }
+
+    case AddSample ⇒
+      context become fullyUtilized(tryComplete(s))
+      s.poolSize.foreach(s ⇒ report(PoolUtilized(s))) //take the chance to report utilization to reporter
+
+  }
+
+  def partialUtilized(poolSize: Option[Int]): Receive = handleSubscriptions orElse {
+    case DispatchResult(idle, workLeft) if settings.fullyUtilized(idle) ⇒
+      context become fullyUtilized(QueueStatus(poolSize = poolSize))
+      reportQueueLength(workLeft)
+
+    case DispatchResult(idle, _) ⇒
+      publishUtilization(idle, poolSize)
+    case metric: Metric ⇒
+      handle(metric) {
+        case PoolSize(s) ⇒
+          context become partialUtilized(Some(s))
+      }
+    case AddSample ⇒
+  }
+
+  /**
+   *
+   * @param status
+   * @return a reset status if completes, the original status if not.
+   */
+  private def tryComplete(status: QueueStatus): QueueStatus = {
+    status.toSample(minSampleDuration).fold(status) { sample ⇒
+      publish(sample)
+      status.copy(workDone = 0, start = Time.now)
+    }
+  }
+  def publish(report: Report): Unit = {
+    subscribers.foreach(_ ! report)
+  }
+
+}
+
+private[dispatcher] object PerformanceSampler {
+  case object AddSample
+
+  case class Subscribe(actorRef: ActorRef)
+  case class Unsubscribe(actorRef: ActorRef)
+
+  case class DispatchResult(workersLeft: Int, workLeft: Int)
+
+  /**
+   *
+   * @param sampleRate
+   * @param minSampleDurationRatio minimum sample duration ratio to sample rate. Sample duration less than this will be abandoned.
+   * @param fullyUtilized a function that given the number of idle workers indicate if the pool is fully utilized
+   */
+  case class PerformanceSamplerSettings(
+    sampleRate:             FiniteDuration = 1.second,
+    minSampleDurationRatio: Double         = 0.3,
+    fullyUtilized:          Int ⇒ Boolean  = _ == 0
+  ) {
+    val minSampleDuration: Duration = sampleRate * minSampleDurationRatio
+  }
+
+  case class QueueStatus(
+    workDone: Int         = 0,
+    start:    Time        = Time.now,
+    poolSize: Option[Int] = None
+  ) {
+
+    def toSample(minSampleDuration: Duration): Option[Sample] = {
+      val end = Time.now
+      if (start.until(end) > minSampleDuration
+        && workDone > 0
+        && poolSize.isDefined) Some(Sample(
+        workDone = workDone,
+        start = start,
+        end = Time.now,
+        poolSize = poolSize.get
+      ))
+      else
+        None
+    }
+  }
+
+  sealed trait Report
+
+  case class Sample(
+    workDone: Int,
+    start:    Time,
+    end:      Time,
+    poolSize: Int
+  ) extends Report
+
+  /**
+   * Number of utilized the workers in the worker when not all workers in the pool are busy
+   *
+   * @param numOfBusyWorkers
+   */
+  case class PartialUtilization(numOfBusyWorkers: Int) extends Report
+}

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Metric.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Metric.scala
@@ -20,6 +20,7 @@ object Metric {
 
   case class PoolSize(size: Int) extends Status
   case class PoolUtilized(numWorkers: Int) extends Status
+  case class PoolIdle(size: Int) extends Status
   case class ProcessTime(duration: Duration) extends Status
   case class WorkQueueLength(length: Int) extends Status
   case class WorkQueueExpectedWaitTime(duration: Duration) extends Status

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Metric.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Metric.scala
@@ -10,7 +10,6 @@ object Metric {
   case object WorkEnqueued extends Event
   case object EnqueueRejected extends Event
 
-  case object WorkCompleted extends Event
   case object WorkTimedOut extends Event
   case object WorkFailed extends Event
 
@@ -20,9 +19,9 @@ object Metric {
 
   case class PoolSize(size: Int) extends Status
   case class PoolUtilized(numWorkers: Int) extends Status
-  case class PoolIdle(size: Int) extends Status
-  case class ProcessTime(duration: Duration) extends Status
   case class WorkQueueLength(length: Int) extends Status
   case class WorkQueueExpectedWaitTime(duration: Duration) extends Status
+
+  case class WorkCompleted(processTime: Duration) extends Event with Status
 }
 

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollector.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollector.scala
@@ -1,24 +1,8 @@
 package kanaloa.reactive.dispatcher.metrics
 
-import akka.actor.ActorSystem
-import com.typesafe.config.{ConfigFactory, Config}
+class MetricsCollector(val reporter: Option[Reporter]) {
 
-trait MetricsCollector {
-  def send(metric: Metric): Unit
-}
-
-object NoOpMetricsCollector extends MetricsCollector {
-  def send(metric: Metric): Unit = () // Do nothing
-}
-
-object MetricsCollector {
-  /** If statsd config exists, create StatsD, otherwise NoOp */
-  def fromConfig(dispatcherName: String, config: Config)(implicit system: ActorSystem): MetricsCollector = {
-    import net.ceedubs.ficus.Ficus._
-    import net.ceedubs.ficus.readers.ArbitraryTypeReader._
-
-    val defaultSettings = config.as[Option[StatsDMetricsCollectorSettings]]("metrics.statsd").filter(_ ⇒ config.getOrElse("metrics.enabled", true))
-
-    defaultSettings.fold(NoOpMetricsCollector: MetricsCollector)(StatsDMetricsCollector(dispatcherName, _))
+  def send(metrics: Metric): Unit = {
+    reporter.foreach(_.report(metrics))
   }
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollector.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollector.scala
@@ -1,8 +1,14 @@
 package kanaloa.reactive.dispatcher.metrics
 
-class MetricsCollector(val reporter: Option[Reporter]) {
+import akka.actor.ActorRefFactory
+
+class MetricsCollector(val reporter: Option[Reporter])(implicit actorRefFactory: ActorRefFactory) {
 
   def send(metrics: Metric): Unit = {
     reporter.foreach(_.report(metrics))
   }
+}
+
+object MetricsCollector {
+  def apply(reporter: Option[Reporter])(implicit actorRefFactory: ActorRefFactory): MetricsCollector = new MetricsCollector(reporter)
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollector.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollector.scala
@@ -3,6 +3,8 @@ package kanaloa.reactive.dispatcher.metrics
 import java.time.{LocalDateTime ⇒ Time}
 
 import akka.actor._
+import kanaloa.reactive.dispatcher.PerformanceSampler
+import kanaloa.reactive.dispatcher.PerformanceSampler.PerformanceSamplerSettings
 import kanaloa.reactive.dispatcher.metrics.Metric._
 import kanaloa.reactive.dispatcher.metrics.MetricsCollector._
 
@@ -11,200 +13,37 @@ import kanaloa.util.Java8TimeExtensions._
 
 /**
  *  A metrics collector to which all [[Metric]] are sent to.
- *  It proxy the incoming [[Metric]]s to [[reporter]].
- *  Internally it collects performance [[Sample]] from [[WorkCompleted]] and [[WorkFailed]]
- *  when the system is in fullyUtilized state, namely when number
- *  of idle workers is less than [[MetricsCollectorSettings]]
- *  It internally publishes these [[Sample]]s as well as [[PartialUtilization]] data
- *  which are only for internal tuning purpose, and should not be
- *  confused with the [[Metric]] used for realtime monitoring.
- *  It can be subscribed using [[Subscribe]] message.
- *  It publishes [[Sample]]s and [[PartialUtilization]] number to subscribers.
- * @param reporter
- * @param settings
+ *  This can be mixed in to inject other metrics related behavior, see [[PerformanceSampler]]
  */
-private[metrics] class MetricsCollector(
-  reporter: Option[Reporter],
-  settings: MetricsCollectorSettings
+trait MetricsCollector extends Actor {
 
-) extends Actor {
-  import settings._
-  var subscribers: Set[ActorRef] = Set.empty
+  def reporter: Option[Reporter]
 
-  val scheduledSampling = {
-    import context.dispatcher
-    context.system.scheduler.schedule(
-      sampleRate,
-      sampleRate,
-      self,
-      AddSample
-    )
-  }
-
-  override def postStop(): Unit = {
-    scheduledSampling.cancel()
-    super.postStop()
-  }
-
-  def receive = partialUtilized(None)
-
-  def handleSubscriptions: Receive = {
-    case Subscribe(s) ⇒
-      subscribers += s
-      context watch s
-    case Unsubscribe(s) ⇒
-      subscribers -= s
-      context unwatch s
-    case Terminated(s) ⇒
-      subscribers -= s
-  }
-
-  def publishUtilization(idle: Int, poolSizeO: Option[Int]): Unit = {
-    poolSizeO.foreach { poolSize ⇒
-      val utilization = poolSize - idle
-      publish(PartialUtilization(utilization))
-      reporter.foreach(_.report(PoolUtilized(utilization)))
-    }
-  }
-
-  def reportQueueLength(workLeft: Int): Unit =
-    reporter.foreach(_.report(WorkQueueLength(workLeft)))
-
-  def fullyUtilized(s: QueueStatus): Receive = handleSubscriptions orElse {
-    case DispatchResult(idle, workLeft) ⇒
-      reportQueueLength(workLeft)
-      if (!settings.fullyUtilized(idle)) {
-        tryComplete(s)
-        publishUtilization(idle, s.poolSize)
-        context become partialUtilized(s.poolSize)
-      }
-
-    case metric: Metric ⇒
-      handle(metric) {
-        case WorkCompleted(_) | WorkFailed ⇒
-          continue(s.copy(workDone = s.workDone + 1))
-
-        case PoolSize(size) ⇒
-          val sizeChanged = s.poolSize.fold(true)(_ != size)
-          if (sizeChanged) {
-            tryComplete(s)
-            continue(QueueStatus(poolSize = Some(size)))
-          }
-      }
-
-    case AddSample ⇒
-      continue(tryComplete(s))
-      for (r ← reporter; s ← s.poolSize) r.report(PoolUtilized(s)) //take the chance to report utilization to reporter
-
-  }
-
-  def partialUtilized(poolSize: Option[Int]): Receive = handleSubscriptions orElse {
-    case DispatchResult(idle, workLeft) if settings.fullyUtilized(idle) ⇒
-      context become fullyUtilized(QueueStatus(poolSize = poolSize))
-      reportQueueLength(workLeft)
-
-    case DispatchResult(idle, _) ⇒
-      publishUtilization(idle, poolSize)
-    case metric: Metric ⇒
-      handle(metric) {
-        case PoolSize(s) ⇒
-          context become partialUtilized(Some(s))
-      }
-    case AddSample ⇒
-  }
-
-  private def continue(qs: QueueStatus): Unit = context become fullyUtilized(qs)
-
-  /**
-   *
-   * @param status
-   * @return a reset status if completes, the original status if not.
-   */
-  private def tryComplete(status: QueueStatus): QueueStatus = {
-    status.toSample(minSampleDuration).fold(status) { sample ⇒
-      publish(sample)
-      status.copy(workDone = 0, start = Time.now)
-    }
-  }
-
-  private def handle(metric: Metric)(pf: PartialFunction[Metric, Unit]): Unit = {
-    reporter.foreach(_.report(metric))
+  protected def handle(metric: Metric)(pf: PartialFunction[Metric, Unit]): Unit = {
+    report(metric)
     pf.applyOrElse(metric, (_: Metric) ⇒ ())
   }
 
-  def publish(report: Report): Unit = {
-    subscribers.foreach(_ ! report)
-  }
+  protected def report(metric: Metric): Unit =
+    if (!reporter.isEmpty) reporter.get.report(metric) //better performance than Option.foreach
+
 }
 
-private[kanaloa] object MetricsCollector {
+private[dispatcher] object MetricsCollector {
+
+  class MetricsCollectorImpl(
+    val reporter: Option[Reporter],
+    val settings: PerformanceSamplerSettings
+  ) extends MetricsCollector with PerformanceSampler
 
   def props(
     reporter: Option[Reporter],
-    settings: MetricsCollectorSettings = MetricsCollectorSettings()
-  ): Props = Props(new MetricsCollector(reporter, settings))
+    settings: PerformanceSamplerSettings = PerformanceSamplerSettings()
+  ): Props = Props(new MetricsCollectorImpl(reporter, settings))
 
   def apply(
     reporter: Option[Reporter],
-    settings: MetricsCollectorSettings = MetricsCollectorSettings()
+    settings: PerformanceSamplerSettings = PerformanceSamplerSettings()
   )(implicit system: ActorSystem): ActorRef = system.actorOf(props(reporter, settings))
-
-  case object AddSample
-
-  case class Subscribe(actorRef: ActorRef)
-  case class Unsubscribe(actorRef: ActorRef)
-
-  case class DispatchResult(workersLeft: Int, workLeft: Int)
-
-  /**
-   *
-   * @param sampleRate
-   * @param minSampleDurationRatio minimum sample duration ratio to sample rate. Sample duration less than this will be abandoned.
-   * @param fullyUtilized a function that given the number of idle workers indicate if the pool is fully utilized
-   */
-  case class MetricsCollectorSettings(
-    sampleRate:             FiniteDuration = 1.second,
-    minSampleDurationRatio: Double         = 0.3,
-    fullyUtilized:          Int ⇒ Boolean  = _ == 0
-  ) {
-    val minSampleDuration: Duration = sampleRate * minSampleDurationRatio
-  }
-
-  case class QueueStatus(
-    workDone: Int         = 0,
-    start:    Time        = Time.now,
-    poolSize: Option[Int] = None
-  ) {
-
-    def toSample(minSampleDuration: Duration): Option[Sample] = {
-      val end = Time.now
-      if (start.until(end) > minSampleDuration
-        && workDone > 0
-        && poolSize.isDefined) Some(Sample(
-        workDone = workDone,
-        start = start,
-        end = Time.now,
-        poolSize = poolSize.get
-      ))
-      else
-        None
-    }
-  }
-
-  sealed trait Report
-
-  case class Sample(
-    workDone: Int,
-    start:    Time,
-    end:      Time,
-    poolSize: Int
-  ) extends Report
-
-  /**
-   * Number of utilized the workers in the worker when not all workers in the pool are busy
-   *
-   * @param numOfBusyWorkers
-   */
-  case class PartialUtilization(numOfBusyWorkers: Int) extends Report
 
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollector.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollector.scala
@@ -1,14 +1,189 @@
 package kanaloa.reactive.dispatcher.metrics
 
-import akka.actor.ActorRefFactory
+import java.time.{LocalDateTime ⇒ Time}
 
-class MetricsCollector(val reporter: Option[Reporter])(implicit actorRefFactory: ActorRefFactory) {
+import akka.actor._
+import kanaloa.reactive.dispatcher.metrics.Metric._
+import kanaloa.reactive.dispatcher.metrics.MetricsCollector._
 
-  def send(metrics: Metric): Unit = {
-    reporter.foreach(_.report(metrics))
+import scala.concurrent.duration._
+import kanaloa.util.FiniteCollection._
+import kanaloa.util.Java8TimeExtensions._
+import akka.agent.Agent
+
+class MetricsCollector(
+  reporter: Option[Reporter],
+  settings: Settings
+) extends Actor {
+
+  var subscribers: Set[ActorRef] = Set.empty
+
+  val scheduledSampling = {
+    import context.dispatcher
+    context.system.scheduler.schedule(
+      settings.sampleRate,
+      settings.sampleRate,
+      self,
+      AddSample
+    )
+  }
+
+  override def postStop(): Unit = {
+    scheduledSampling.cancel()
+    super.postStop()
+  }
+
+  def receive = casual(None)
+
+  def handleSubscriptions: Receive = {
+    case Subscribe(s) ⇒
+      subscribers += s
+      context watch s
+    case Unsubscribe(s) ⇒
+      subscribers -= s
+      context unwatch s
+    case Terminated(s) ⇒
+      subscribers -= s
+  }
+
+  def publishUtilization(idle: Int, poolSizeO: Option[Int]): Unit = {
+    poolSizeO.foreach { poolSize ⇒
+      publish(PartialUtilization(poolSize - idle))
+    }
+  }
+
+  /**
+   *
+   * @param s
+   * @return
+   */
+  def busy(s: QueueStatus): Receive = handleSubscriptions orElse {
+    case PoolIdle(size) if size > 0 ⇒
+      tryComplete(s)
+      publishUtilization(size, s.poolSize)
+      context become casual(s.poolSize)
+
+    case metric: Metric ⇒
+      handle(metric) {
+        case WorkCompleted | WorkFailed ⇒
+          continue(s.copy(workDone = s.workDone + 1))
+
+        case PoolSize(size) ⇒
+          val sizeChanged = s.poolSize.fold(true)(_ != size)
+          if (sizeChanged) {
+            tryComplete(s)
+            continue(QueueStatus(poolSize = Some(size)))
+          }
+      }
+
+    case AddSample ⇒
+      continue(tryComplete(s))
+
+  }
+
+  /**
+   * keep it low when the pool isn't fully occupied.
+   */
+  def casual(poolSize: Option[Int]): Receive = handleSubscriptions orElse {
+    case PoolIdle(size) if size == 0 ⇒
+      context become busy(QueueStatus(poolSize = poolSize))
+    case PoolIdle(idle) ⇒
+      publishUtilization(idle, poolSize)
+    case metric: Metric ⇒
+      handle(metric) {
+        case PoolSize(s) ⇒ context become casual(Some(s))
+      }
+    case AddSample ⇒
+  }
+
+  private def continue(qs: QueueStatus): Unit = context become busy(qs)
+
+  /**
+   *
+   * @param status
+   * @return a reset status if completes, the original status if not.
+   */
+  private def tryComplete(status: QueueStatus): QueueStatus = {
+    status.toSample(settings.minSampleDuration).fold(status) { sample ⇒
+      publish(sample)
+      status.copy(workDone = 0, start = Time.now)
+    }
+  }
+
+  private def handle(metric: Metric)(pf: PartialFunction[Metric, Unit]): Unit = {
+    reporter.foreach(_.report(metric))
+    pf.applyOrElse(metric, (_: Metric) ⇒ ())
+  }
+
+  def publish(report: Report): Unit = {
+    subscribers.foreach(_ ! report)
   }
 }
 
 object MetricsCollector {
-  def apply(reporter: Option[Reporter])(implicit actorRefFactory: ActorRefFactory): MetricsCollector = new MetricsCollector(reporter)
+
+  def props(
+    reporter: Option[Reporter],
+    settings: Settings         = Settings()
+  ): Props = Props(new MetricsCollector(reporter, settings))
+
+  def apply(
+    reporter: Option[Reporter],
+    settings: Settings         = Settings()
+  )(implicit system: ActorSystem): ActorRef = system.actorOf(props(reporter, settings))
+
+  case object AddSample
+
+  case class Subscribe(actorRef: ActorRef)
+  case class Unsubscribe(actorRef: ActorRef)
+
+  /**
+   *
+   * @param sampleRate
+   * @param minSampleDurationRatio minimum sample duration ratio to sample rate. Sample duration less than this will be abandoned.
+   */
+  case class Settings(
+    sampleRate:             FiniteDuration = 1.second,
+    minSampleDurationRatio: Double         = 0.3
+  ) {
+    val minSampleDuration: Duration = sampleRate * minSampleDurationRatio
+  }
+
+  case class QueueStatus(
+    workDone: Int         = 0,
+    start:    Time        = Time.now,
+    poolSize: Option[Int] = None
+  ) {
+
+    def toSample(minSampleDuration: Duration): Option[Sample] = {
+      val end = Time.now
+      if (start.until(end) > minSampleDuration
+        && workDone > 0
+        && poolSize.isDefined) Some(Sample(
+        workDone = workDone,
+        start = start,
+        end = Time.now,
+        poolSize = poolSize.get
+      ))
+      else
+        None
+    }
+  }
+
+  sealed trait Report
+
+  case class Sample(
+    workDone: Int,
+    start:    Time,
+    end:      Time,
+    poolSize: Int
+  ) extends Report
+
+  /**
+   * Number of utilized the workers in the worker when not all workers in the pool are busy
+   *
+   * @param numOfBusyWorkers
+   */
+  case class PartialUtilization(numOfBusyWorkers: Int) extends Report
+
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsReporterSettings.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/MetricsReporterSettings.scala
@@ -1,11 +1,11 @@
 package kanaloa.reactive.dispatcher.metrics
 
-sealed trait MetricsCollectorSettings
+sealed trait MetricsReporterSettings
 
-case class StatsDMetricsCollectorSettings(
+case class StatsDMetricsReporterSettings(
   host:             String,
   namespace:        String = "reactiveDispatchers",
   port:             Int    = 8125,
   eventSampleRate:  Double = 0.25,
   statusSampleRate: Double = 1
-) extends MetricsCollectorSettings
+) extends MetricsReporterSettings

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Reporter.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Reporter.scala
@@ -1,0 +1,20 @@
+package kanaloa.reactive.dispatcher.metrics
+
+import akka.actor.ActorSystem
+import com.typesafe.config.{ConfigFactory, Config}
+
+trait Reporter {
+  def report(metric: Metric): Unit
+}
+
+object Reporter {
+  /** If statsd config exists, create StatsDReporter, otherwise None */
+  def fromConfig(dispatcherName: String, config: Config)(implicit system: ActorSystem): Option[Reporter] = {
+    import net.ceedubs.ficus.Ficus._
+    import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+
+    val defaultSettings = config.as[Option[StatsDMetricsCollectorSettings]]("metrics.statsd").filter(_ ⇒ config.getOrElse("metrics.enabled", true))
+
+    defaultSettings.map(StatsDReporter(dispatcherName, _))
+  }
+}

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Reporter.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Reporter.scala
@@ -13,7 +13,7 @@ object Reporter {
     import net.ceedubs.ficus.Ficus._
     import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 
-    val defaultSettings = config.as[Option[StatsDMetricsCollectorSettings]]("metrics.statsd").filter(_ ⇒ config.getOrElse("metrics.enabled", true))
+    val defaultSettings = config.as[Option[StatsDMetricsReporterSettings]]("metrics.statsd").filter(_ ⇒ config.getOrElse("metrics.enabled", true))
 
     defaultSettings.map(StatsDReporter(dispatcherName, _))
   }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/StatsDReporter.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/StatsDReporter.scala
@@ -65,6 +65,8 @@ class StatsDReporter(
     case WorkQueueLength(length) ⇒
       gauge("queue.length", length)
 
+    case PoolIdle(_) ⇒ //ignore this metric, it is mostly for metrics control
+
   }
 }
 

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/StatsDReporter.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/StatsDReporter.scala
@@ -25,7 +25,7 @@ class StatsDReporter(
    */
   def this(
     prefix:   String,
-    settings: StatsDMetricsCollectorSettings
+    settings: StatsDMetricsReporterSettings
   )(implicit system: ActorSystem) =
     this(new StatsDClient(system, settings.host, settings.port, prefix = prefix), settings.eventSampleRate, settings.statusSampleRate)
 
@@ -77,7 +77,7 @@ object StatsDReporter {
    * @param dispatcherName used to determine the metrics prefix (`namespace.dispatcherName`)
    * @param settings
    */
-  def apply(dispatcherName: String, settings: StatsDMetricsCollectorSettings)(implicit system: ActorSystem): StatsDReporter = {
+  def apply(dispatcherName: String, settings: StatsDMetricsReporterSettings)(implicit system: ActorSystem): StatsDReporter = {
     val prefix: String = List(settings.namespace, dispatcherName).filter(_.nonEmpty).mkString(".")
 
     new StatsDReporter(prefix, settings)

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/StatsDReporter.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/StatsDReporter.scala
@@ -10,12 +10,12 @@ import akka.actor._
  * @param eventSampleRate sample rate for countable events (WorkEnqueued, WorkCompleted, etc)
  * @param statusSampleRate sample rate for gauged events (PoolSize, WorkQueueLength, etc)
  */
-class StatsDMetricsCollector(
+class StatsDReporter(
   statsd:               StatsDClient,
   val eventSampleRate:  Double,
   val statusSampleRate: Double
 )(implicit system: ActorSystem)
-  extends MetricsCollector {
+  extends Reporter {
 
   /**
    * Auxilliary constructor that creates a StatsDClient from params
@@ -42,7 +42,7 @@ class StatsDMetricsCollector(
    */
   val failureSampleRate: Double = 1.0
 
-  def send(metric: Metric): Unit = metric match {
+  def report(metric: Metric): Unit = metric match {
     case WorkEnqueued         ⇒ increment("queue.enqueued")
     case EnqueueRejected      ⇒ increment("queue.enqueueRejected")
     case WorkCompleted        ⇒ increment("work.completed")
@@ -68,17 +68,17 @@ class StatsDMetricsCollector(
   }
 }
 
-object StatsDMetricsCollector {
+object StatsDReporter {
   /**
    * Create a StatsDMetricsCollector from typesafe Config object
    *
    * @param dispatcherName used to determine the metrics prefix (`namespace.dispatcherName`)
    * @param settings
    */
-  def apply(dispatcherName: String, settings: StatsDMetricsCollectorSettings)(implicit system: ActorSystem): StatsDMetricsCollector = {
+  def apply(dispatcherName: String, settings: StatsDMetricsCollectorSettings)(implicit system: ActorSystem): StatsDReporter = {
     val prefix: String = List(settings.namespace, dispatcherName).filter(_.nonEmpty).mkString(".")
 
-    new StatsDMetricsCollector(prefix, settings)
+    new StatsDReporter(prefix, settings)
   }
 }
 

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
@@ -53,7 +53,7 @@ trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
   private def collectingStatus(status: SystemStatus): Receive = watchingQueueAndProcessor orElse {
     case qdi: QueueDispatchInfo ⇒
       processor ! QueryStatus()
-      continueCollectingStatus(status.copy(dispatchWaitWhenFullyUtilized = qdi.avgDispatchDurationLowerBoundWhenFullyUtilized))
+      continueCollectingStatus(status.copy(dispatchWaitWhenFullyUtilized = qdi.avgDequeueDurationLowerBoundWhenFullyUtilized))
 
     case RunningStatus(pool) ⇒
       pool.foreach(_ ! QueryStatus())

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
@@ -4,7 +4,7 @@ import java.time.{Duration ⇒ JDuration, LocalDateTime}
 
 import akka.actor._
 import kanaloa.reactive.dispatcher.ApiProtocol.QueryStatus
-import kanaloa.reactive.dispatcher.metrics.{Metric, MetricsCollector, NoOpMetricsCollector}
+import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, Metric}
 import kanaloa.reactive.dispatcher.queue.AutoScaling._
 import kanaloa.reactive.dispatcher.queue.Queue.QueueDispatchInfo
 import kanaloa.reactive.dispatcher.queue.QueueProcessor.{ScaleTo, _}
@@ -178,15 +178,14 @@ object AutoScaling {
     queue:            QueueRef,
     processor:        QueueProcessorRef,
     settings:         AutoScalingSettings,
-    metricsCollector: MetricsCollector    = NoOpMetricsCollector
+    metricsCollector: MetricsCollector    = new MetricsCollector(None)
   ) extends AutoScaling
 
   def default(
     queue:            QueueRef,
     processor:        QueueProcessorRef,
     settings:         AutoScalingSettings,
-    metricsCollector: MetricsCollector    = NoOpMetricsCollector
-  ) =
-    Props(Default(queue, processor, settings, metricsCollector)).withDeploy(Deploy.local)
+    metricsCollector: MetricsCollector    = new MetricsCollector(None)
+  ) = Props(Default(queue, processor, settings, metricsCollector)).withDeploy(Deploy.local)
 }
 

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
@@ -15,28 +15,28 @@ import scala.language.implicitConversions
 import scala.util.Random
 
 /**
-  *  Auto-scales the work pool to an optimal size that provides the highest throughput.
-  *  This auto-scaling works best when you expect the pool size to performance function
-  *  to be a convex function, with which you can find a global optimal by walking towards
-  *  a better size. For example, a CPU bound service may have an optimal worker pool size
-  *  tied to the CPU cores available. When your service is IO bound, the optimal size is
-  *  bound to optimal number of concurrent connections to that IO service - e.g. a 4 node
-  *  Elasticsearch cluster may handle 4-8 concurrent requests at optimal speed.
-  *  The dispatchers keep track of throughput at each pool size and perform the following
-  *  three resizing operations (one at a time) periodically:
-  *  1. Downsize if it hasn't seen all workers ever fully utilized for a period of time.
-  *  2. Explore to a random nearby pool size to try and collect throughput metrics.
-  *  3. Optimize to a nearby pool size with a better (than any other nearby sizes)
-  *     throughput metrics.
-  *  When the pool is fully-utilized (i.e. all workers are busy), it randomly chooses
-  *  between exploring and optimizing. When the pool has not been fully-utilized for a period of
-  *  time, it will downsize the pool to the last seen max utilization multiplied by
-  *  a configurable ratio.
-  *
-  *  By constantly exploring and optimizing, the resizer will eventually walk to the optimal
-  *  size and remain nearby.
-  *  When the optimal size changes it will start walking towards the new one.
-  */
+ *  Auto-scales the work pool to an optimal size that provides the highest throughput.
+ *  This auto-scaling works best when you expect the pool size to performance function
+ *  to be a convex function, with which you can find a global optimal by walking towards
+ *  a better size. For example, a CPU bound service may have an optimal worker pool size
+ *  tied to the CPU cores available. When your service is IO bound, the optimal size is
+ *  bound to optimal number of concurrent connections to that IO service - e.g. a 4 node
+ *  Elasticsearch cluster may handle 4-8 concurrent requests at optimal speed.
+ *  The dispatchers keep track of throughput at each pool size and perform the following
+ *  three resizing operations (one at a time) periodically:
+ *  1. Downsize if it hasn't seen all workers ever fully utilized for a period of time.
+ *  2. Explore to a random nearby pool size to try and collect throughput metrics.
+ *  3. Optimize to a nearby pool size with a better (than any other nearby sizes)
+ *     throughput metrics.
+ *  When the pool is fully-utilized (i.e. all workers are busy), it randomly chooses
+ *  between exploring and optimizing. When the pool has not been fully-utilized for a period of
+ *  time, it will downsize the pool to the last seen max utilization multiplied by
+ *  a configurable ratio.
+ *
+ *  By constantly exploring and optimizing, the resizer will eventually walk to the optimal
+ *  size and remain nearby.
+ *  When the optimal size changes it will start walking towards the new one.
+ */
 trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
   val processor: QueueProcessorRef
   val metricsCollector: ActorRef
@@ -53,7 +53,7 @@ trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
     super.preStart()
     metricsCollector ! Subscribe(self)
     import context.dispatcher
-    actionScheduler = Some(context.system.scheduler.schedule(actionInterval, actionInterval, self, OptimizeOrExplore))
+    actionScheduler = Some(context.system.scheduler.schedule(scalingInterval, scalingInterval, self, OptimizeOrExplore))
   }
 
   override def postStop(): Unit = {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
@@ -14,6 +14,29 @@ import scala.concurrent.duration._
 import scala.language.implicitConversions
 import scala.util.Random
 
+/**
+  *  Auto-scales the work pool to an optimal size that provides the highest throughput.
+  *  This auto-scaling works best when you expect the pool size to performance function
+  *  to be a convex function, with which you can find a global optimal by walking towards
+  *  a better size. For example, a CPU bound service may have an optimal worker pool size
+  *  tied to the CPU cores available. When your service is IO bound, the optimal size is
+  *  bound to optimal number of concurrent connections to that IO service - e.g. a 4 node
+  *  Elasticsearch cluster may handle 4-8 concurrent requests at optimal speed.
+  *  The dispatchers keep track of throughput at each pool size and perform the following
+  *  three resizing operations (one at a time) periodically:
+  *  1. Downsize if it hasn't seen all workers ever fully utilized for a period of time.
+  *  2. Explore to a random nearby pool size to try and collect throughput metrics.
+  *  3. Optimize to a nearby pool size with a better (than any other nearby sizes)
+  *     throughput metrics.
+  *  When the pool is fully-utilized (i.e. all workers are busy), it randomly chooses
+  *  between exploring and optimizing. When the pool has not been fully-utilized for a period of
+  *  time, it will downsize the pool to the last seen max utilization multiplied by
+  *  a configurable ratio.
+  *
+  *  By constantly exploring and optimizing, the resizer will eventually walk to the optimal
+  *  size and remain nearby.
+  *  When the optimal size changes it will start walking towards the new one.
+  */
 trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
   val processor: QueueProcessorRef
   val metricsCollector: ActorRef

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
@@ -4,7 +4,7 @@ import java.time.{Duration ⇒ JDuration, LocalDateTime ⇒ Time}
 
 import akka.actor._
 import kanaloa.reactive.dispatcher.ApiProtocol.QueryStatus
-import kanaloa.reactive.dispatcher.metrics.MetricsCollector.{PartialUtilization, Sample, Subscribe, Unsubscribe}
+import kanaloa.reactive.dispatcher.PerformanceSampler.{PartialUtilization, Sample, Subscribe, Unsubscribe}
 import kanaloa.reactive.dispatcher.queue.AutoScaling._
 import kanaloa.reactive.dispatcher.queue.QueueProcessor.ScaleTo
 import kanaloa.util.Java8TimeExtensions._

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/AutoScaling.scala
@@ -142,7 +142,7 @@ trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
     }
 
     val optimalSize = adjacentDispatchWaits.minBy(_._2)._1
-    val scaleStep = Math.ceil((optimalSize - currentSize) / 2).toInt
+    val scaleStep = Math.ceil((optimalSize - currentSize).toDouble / 2.0).toInt
     ScaleTo(currentSize + scaleStep, Some("optimizing"))
   }
 
@@ -178,14 +178,14 @@ object AutoScaling {
     queue:            QueueRef,
     processor:        QueueProcessorRef,
     settings:         AutoScalingSettings,
-    metricsCollector: MetricsCollector    = new MetricsCollector(None)
+    metricsCollector: MetricsCollector
   ) extends AutoScaling
 
   def default(
     queue:            QueueRef,
     processor:        QueueProcessorRef,
     settings:         AutoScalingSettings,
-    metricsCollector: MetricsCollector    = new MetricsCollector(None)
+    metricsCollector: MetricsCollector
   ) = Props(Default(queue, processor, settings, metricsCollector)).withDeploy(Deploy.local)
 }
 

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -139,8 +139,8 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
 case class QueueWithBackPressure(
   dispatchHistorySettings: DispatchHistorySettings,
   backPressureSettings:    BackPressureSettings,
-  defaultWorkSettings:     WorkSettings            = WorkSettings(),
-  metricsCollector:        MetricsCollector        = new MetricsCollector(None)
+  metricsCollector:        MetricsCollector,
+  defaultWorkSettings:     WorkSettings            = WorkSettings()
 ) extends Queue {
 
   def checkOverCapacity(qs: QueueStatus): Boolean =
@@ -165,15 +165,15 @@ trait QueueWithoutBackPressure extends Queue {
 case class DefaultQueue(
   dispatchHistorySettings: DispatchHistorySettings,
   defaultWorkSettings:     WorkSettings,
-  metricsCollector:        MetricsCollector        = new MetricsCollector(None)
+  metricsCollector:        MetricsCollector
 ) extends QueueWithoutBackPressure
 
 class QueueOfIterator(
   private val iterator:        Iterator[_],
   val dispatchHistorySettings: DispatchHistorySettings,
   val defaultWorkSettings:     WorkSettings,
-  sendResultsTo:               Option[ActorRef]        = None,
-  val metricsCollector:        MetricsCollector        = new MetricsCollector(None)
+  val metricsCollector:        MetricsCollector,
+  sendResultsTo:               Option[ActorRef]        = None
 ) extends QueueWithoutBackPressure {
   import QueueOfIterator._
 
@@ -192,10 +192,10 @@ object QueueOfIterator {
     iterator:                Iterator[_],
     dispatchHistorySettings: DispatchHistorySettings,
     defaultWorkSettings:     WorkSettings,
-    sendResultsTo:           Option[ActorRef]        = None,
-    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
+    metricsCollector:        MetricsCollector,
+    sendResultsTo:           Option[ActorRef]        = None
   ): Props =
-    Props(new QueueOfIterator(iterator, dispatchHistorySettings, defaultWorkSettings, sendResultsTo, metricsCollector)).withDeploy(Deploy.local)
+    Props(new QueueOfIterator(iterator, dispatchHistorySettings, defaultWorkSettings, metricsCollector, sendResultsTo)).withDeploy(Deploy.local)
 
   private case object EnqueueMore
 
@@ -294,35 +294,35 @@ object Queue {
   def ofIterable(
     iterable:                Iterable[_],
     dispatchHistorySettings: DispatchHistorySettings,
+    metricsCollector:        MetricsCollector,
     defaultWorkSetting:      WorkSettings            = WorkSettings(),
-    sendResultsTo:           Option[ActorRef]        = None,
-    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
+    sendResultsTo:           Option[ActorRef]        = None
   ): Props =
-    QueueOfIterator.props(iterable.iterator, dispatchHistorySettings, defaultWorkSetting, sendResultsTo, metricsCollector).withDeploy(Deploy.local)
+    QueueOfIterator.props(iterable.iterator, dispatchHistorySettings, defaultWorkSetting, metricsCollector, sendResultsTo).withDeploy(Deploy.local)
 
   def ofIterator(
     iterator:                Iterator[_],
     dispatchHistorySettings: DispatchHistorySettings,
+    metricsCollector:        MetricsCollector,
     defaultWorkSetting:      WorkSettings            = WorkSettings(),
-    sendResultsTo:           Option[ActorRef]        = None,
-    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
+    sendResultsTo:           Option[ActorRef]        = None
   ): Props =
-    QueueOfIterator.props(iterator, dispatchHistorySettings, defaultWorkSetting, sendResultsTo, metricsCollector).withDeploy(Deploy.local)
+    QueueOfIterator.props(iterator, dispatchHistorySettings, defaultWorkSetting, metricsCollector, sendResultsTo).withDeploy(Deploy.local)
 
   def default(
+    metricsCollector:        MetricsCollector,
     dispatchHistorySettings: DispatchHistorySettings = DispatchHistorySettings(),
-    defaultWorkSetting:      WorkSettings            = WorkSettings(),
-    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
+    defaultWorkSetting:      WorkSettings            = WorkSettings()
   ): Props =
     Props(new DefaultQueue(dispatchHistorySettings, defaultWorkSetting, metricsCollector)).withDeploy(Deploy.local)
 
   def withBackPressure(
     dispatchHistorySettings: DispatchHistorySettings,
     backPressureSetting:     BackPressureSettings,
-    defaultWorkSettings:     WorkSettings            = WorkSettings(),
-    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
+    metricsCollector:        MetricsCollector,
+    defaultWorkSettings:     WorkSettings            = WorkSettings()
   ): Props =
-    Props(QueueWithBackPressure(dispatchHistorySettings, backPressureSetting, defaultWorkSettings, metricsCollector)).withDeploy(Deploy.local)
+    Props(QueueWithBackPressure(dispatchHistorySettings, backPressureSetting, metricsCollector, defaultWorkSettings)).withDeploy(Deploy.local)
 
 }
 

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 import akka.actor._
 import kanaloa.reactive.dispatcher.ApiProtocol.{QueryStatus, WorkRejected}
-import kanaloa.reactive.dispatcher.metrics.{Metric, MetricsCollector, NoOpMetricsCollector}
+import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, Metric}
 import kanaloa.reactive.dispatcher.queue.Queue.{QueueStatus, _}
 import kanaloa.util.FiniteCollection._
 import kanaloa.util.Java8TimeExtensions._
@@ -140,7 +140,7 @@ case class QueueWithBackPressure(
   dispatchHistorySettings: DispatchHistorySettings,
   backPressureSettings:    BackPressureSettings,
   defaultWorkSettings:     WorkSettings            = WorkSettings(),
-  metricsCollector:        MetricsCollector        = NoOpMetricsCollector
+  metricsCollector:        MetricsCollector        = new MetricsCollector(None)
 ) extends Queue {
 
   def checkOverCapacity(qs: QueueStatus): Boolean =
@@ -165,7 +165,7 @@ trait QueueWithoutBackPressure extends Queue {
 case class DefaultQueue(
   dispatchHistorySettings: DispatchHistorySettings,
   defaultWorkSettings:     WorkSettings,
-  metricsCollector:        MetricsCollector        = NoOpMetricsCollector
+  metricsCollector:        MetricsCollector        = new MetricsCollector(None)
 ) extends QueueWithoutBackPressure
 
 class QueueOfIterator(
@@ -173,7 +173,7 @@ class QueueOfIterator(
   val dispatchHistorySettings: DispatchHistorySettings,
   val defaultWorkSettings:     WorkSettings,
   sendResultsTo:               Option[ActorRef]        = None,
-  val metricsCollector:        MetricsCollector        = NoOpMetricsCollector
+  val metricsCollector:        MetricsCollector        = new MetricsCollector(None)
 ) extends QueueWithoutBackPressure {
   import QueueOfIterator._
 
@@ -193,7 +193,7 @@ object QueueOfIterator {
     dispatchHistorySettings: DispatchHistorySettings,
     defaultWorkSettings:     WorkSettings,
     sendResultsTo:           Option[ActorRef]        = None,
-    metricsCollector:        MetricsCollector        = NoOpMetricsCollector
+    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
   ): Props =
     Props(new QueueOfIterator(iterator, dispatchHistorySettings, defaultWorkSettings, sendResultsTo, metricsCollector)).withDeploy(Deploy.local)
 
@@ -296,7 +296,7 @@ object Queue {
     dispatchHistorySettings: DispatchHistorySettings,
     defaultWorkSetting:      WorkSettings            = WorkSettings(),
     sendResultsTo:           Option[ActorRef]        = None,
-    metricsCollector:        MetricsCollector        = NoOpMetricsCollector
+    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
   ): Props =
     QueueOfIterator.props(iterable.iterator, dispatchHistorySettings, defaultWorkSetting, sendResultsTo, metricsCollector).withDeploy(Deploy.local)
 
@@ -305,14 +305,14 @@ object Queue {
     dispatchHistorySettings: DispatchHistorySettings,
     defaultWorkSetting:      WorkSettings            = WorkSettings(),
     sendResultsTo:           Option[ActorRef]        = None,
-    metricsCollector:        MetricsCollector        = NoOpMetricsCollector
+    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
   ): Props =
     QueueOfIterator.props(iterator, dispatchHistorySettings, defaultWorkSetting, sendResultsTo, metricsCollector).withDeploy(Deploy.local)
 
   def default(
     dispatchHistorySettings: DispatchHistorySettings = DispatchHistorySettings(),
     defaultWorkSetting:      WorkSettings            = WorkSettings(),
-    metricsCollector:        MetricsCollector        = NoOpMetricsCollector
+    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
   ): Props =
     Props(new DefaultQueue(dispatchHistorySettings, defaultWorkSetting, metricsCollector)).withDeploy(Deploy.local)
 
@@ -320,7 +320,7 @@ object Queue {
     dispatchHistorySettings: DispatchHistorySettings,
     backPressureSetting:     BackPressureSettings,
     defaultWorkSettings:     WorkSettings            = WorkSettings(),
-    metricsCollector:        MetricsCollector        = NoOpMetricsCollector
+    metricsCollector:        MetricsCollector        = new MetricsCollector(None)
   ): Props =
     Props(QueueWithBackPressure(dispatchHistorySettings, backPressureSetting, defaultWorkSettings, metricsCollector)).withDeploy(Deploy.local)
 

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -4,6 +4,7 @@ import java.time.LocalDateTime
 
 import akka.actor._
 import kanaloa.reactive.dispatcher.ApiProtocol.{QueryStatus, WorkRejected}
+import kanaloa.reactive.dispatcher.PerformanceSampler
 import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, Metric}
 import kanaloa.reactive.dispatcher.queue.Queue.{QueueStatus, _}
 import kanaloa.util.FiniteCollection._
@@ -126,7 +127,7 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
     }) match {
       case Some(newStatus) ⇒ dispatchWork(newStatus, dispatched + 1, retiring) //actually in most cases, either works queue or workers queue is empty after one dispatch
       case None ⇒
-        metricsCollector ! MetricsCollector.DispatchResult(status.queuedWorkers.length, status.workBuffer.length)
+        metricsCollector ! PerformanceSampler.DispatchResult(status.queuedWorkers.length, status.workBuffer.length)
         if (dispatchHistoryLength > 0)
           status.copy(dispatchHistory = updatedHistory)
         else status

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -126,8 +126,7 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
     }) match {
       case Some(newStatus) ⇒ dispatchWork(newStatus, dispatched + 1, retiring) //actually in most cases, either works queue or workers queue is empty after one dispatch
       case None ⇒
-        metricsCollector ! Metric.WorkQueueLength(status.workBuffer.length)
-        metricsCollector ! Metric.PoolIdle(status.queuedWorkers.length)
+        metricsCollector ! MetricsCollector.DispatchResult(status.queuedWorkers.length, status.workBuffer.length)
         if (dispatchHistoryLength > 0)
           status.copy(dispatchHistory = updatedHistory)
         else status

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
@@ -166,7 +166,7 @@ case class DefaultQueueProcessor(
   queue:            QueueRef,
   backend:          Backend,
   settings:         ProcessingWorkerPoolSettings,
-  metricsCollector: MetricsCollector             = new MetricsCollector(None),
+  metricsCollector: MetricsCollector,
   resultChecker:    ResultChecker
 ) extends QueueProcessor {
 
@@ -180,7 +180,7 @@ case class QueueProcessorWithCircuitBreaker(
   backend:                Backend,
   settings:               ProcessingWorkerPoolSettings,
   circuitBreakerSettings: CircuitBreakerSettings,
-  metricsCollector:       MetricsCollector             = new MetricsCollector(None),
+  metricsCollector:       MetricsCollector,
   resultChecker:          ResultChecker
 ) extends QueueProcessor {
 
@@ -214,7 +214,7 @@ object QueueProcessor {
     queue:            QueueRef,
     backend:          Backend,
     settings:         ProcessingWorkerPoolSettings,
-    metricsCollector: MetricsCollector             = new MetricsCollector(None)
+    metricsCollector: MetricsCollector
   )(resultChecker: ResultChecker): Props =
     Props(new DefaultQueueProcessor(
       queue,
@@ -229,7 +229,7 @@ object QueueProcessor {
     backend:                Backend,
     settings:               ProcessingWorkerPoolSettings,
     circuitBreakerSettings: CircuitBreakerSettings,
-    metricsCollector:       MetricsCollector             = new MetricsCollector(None)
+    metricsCollector:       MetricsCollector
   )(resultChecker: ResultChecker): Props =
     Props(new QueueProcessorWithCircuitBreaker(
       queue,

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
@@ -55,12 +55,12 @@ trait QueueProcessor extends Actor with ActorLogging with MessageScheduler {
     {
       case ScaleTo(newPoolSize, reason) ⇒
         log.debug(s"Command to scale to $newPoolSize, currently at ${pool.size} due to ${reason.getOrElse("no reason given")}")
-        metricsCollector ! Metric.PoolSize(newPoolSize)
         val toPoolSize = Math.max(settings.minPoolSize, Math.min(settings.maxPoolSize, newPoolSize))
         val diff = toPoolSize - pool.size
-        if (diff > 0)
+        if (diff > 0) {
+          metricsCollector ! Metric.PoolSize(newPoolSize)
           context become monitoring(resultHistory)(pool ++ (1 to diff).map(_ ⇒ createWorker()))
-        else if (diff < 0)
+        } else if (diff < 0)
           pool.take(-diff).foreach(_ ! Worker.Retire)
 
       case WorkCompleted(worker, duration) ⇒

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -54,7 +54,7 @@ package kanaloa.reactive.dispatcher.queue {
   /**
    *
    * @param chanceOfScalingDownWhenFull chance of scaling down when the worker pool is fully utlized
-   * @param actionInterval  duration between each scaling attempt
+   * @param scalingInterval  duration between each scaling attempt
    * @param downsizeAfterUnderUtilization start to downsize after underutilized for period, should be long enough to include at least one traffic cycle.
    * @param numOfAdjacentSizesToConsiderDuringOptimization during optimization, it only looks at this number of adjacent pool sizes (adjacent to current pool size), to figure out the optimal pool size to move to
    * @param exploreStepSize during exploration, it takes as big a step as this size. It's a ratio to the current pool size, so if the current size is 10 and the exploreStepSize is 0.2, the exploration will be within a range between 8 and 12
@@ -64,7 +64,7 @@ package kanaloa.reactive.dispatcher.queue {
    */
   case class AutoScalingSettings(
     chanceOfScalingDownWhenFull:                    Double         = 0.1,
-    actionInterval:                                 FiniteDuration = 5.seconds,
+    scalingInterval:                                FiniteDuration = 5.seconds,
     downsizeAfterUnderUtilization:                  FiniteDuration = 72.hours,
     numOfAdjacentSizesToConsiderDuringOptimization: Int            = 12,
     exploreStepSize:                                Double         = 0.1,

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -54,7 +54,7 @@ package kanaloa.reactive.dispatcher.queue {
   /**
    *
    * @param chanceOfScalingDownWhenFull chance of scaling down when the worker pool is fully utlized
-   * @param actionFrequency  duration between each scaling attempt
+   * @param actionInterval  duration between each scaling attempt
    * @param downsizeAfterUnderUtilization start to downsize after underutilized for period, should be long enough to include at least one traffic cycle.
    * @param numOfAdjacentSizesToConsiderDuringOptimization during optimization, it only looks at this number of adjacent pool sizes (adjacent to current pool size), to figure out the optimal pool size to move to
    * @param exploreStepSize during exploration, it takes as big a step as this size. It's a ratio to the current pool size, so if the current size is 10 and the exploreStepSize is 0.2, the exploration will be within a range between 8 and 12
@@ -64,7 +64,7 @@ package kanaloa.reactive.dispatcher.queue {
    */
   case class AutoScalingSettings(
     chanceOfScalingDownWhenFull:                    Double         = 0.1,
-    actionFrequency:                                FiniteDuration = 5.seconds,
+    actionInterval:                                 FiniteDuration = 5.seconds,
     downsizeAfterUnderUtilization:                  FiniteDuration = 72.hours,
     numOfAdjacentSizesToConsiderDuringOptimization: Int            = 12,
     exploreStepSize:                                Double         = 0.1,

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
@@ -21,7 +21,7 @@ class DispatcherSpec extends SpecWithActorSystem {
         iterator,
         Dispatcher.defaultDispatcherSettings().copy(workerPool = ProcessingWorkerPoolSettings(1), autoScaling = None),
         backend,
-        metricsCollector = new MetricsCollector(None),
+        metricsCollector = MetricsCollector(None),
         None,
         {
           case Success ⇒ Right(())
@@ -52,7 +52,7 @@ class DispatcherSpec extends SpecWithActorSystem {
         iterator,
         Dispatcher.defaultDispatcherSettings().copy(workerPool = ProcessingWorkerPoolSettings(1), autoScaling = None),
         echoSuccess,
-        metricsCollector = new MetricsCollector(None),
+        metricsCollector = MetricsCollector(None),
         None,
         {
           case Success ⇒ Right(())

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
@@ -107,10 +107,10 @@ class DispatcherSpec extends SpecWithActorSystem {
 
   "readConfig" should {
     "use default settings when nothing is in config" in {
-      val (settings, mc) = Dispatcher.readConfig("example", ConfigFactory.empty)
+      val (settings, reporter) = Dispatcher.readConfig("example", ConfigFactory.empty)
       settings.workRetry === 0
       settings.autoScaling shouldBe defined
-      mc.reporter shouldBe empty
+      reporter shouldBe empty
     }
 
     "use default-dispatcher settings when dispatcher name is missing in the dispatchers section" in {
@@ -234,9 +234,9 @@ class DispatcherSpec extends SpecWithActorSystem {
             }
           """
 
-      val (_, mc) = Dispatcher.readConfig("example", ConfigFactory.parseString(cfgStr))
-      mc.reporter shouldBe a[Some[StatsDReporter]]
-      mc.reporter.get.asInstanceOf[StatsDReporter].eventSampleRate === 0.5
+      val (_, reporter) = Dispatcher.readConfig("example", ConfigFactory.parseString(cfgStr))
+      reporter shouldBe a[Some[StatsDReporter]]
+      reporter.get.asInstanceOf[StatsDReporter].eventSampleRate === 0.5
     }
 
     "turn off metrics collector when disabled at the dispatcher level" in {
@@ -265,11 +265,11 @@ class DispatcherSpec extends SpecWithActorSystem {
           """
 
       val strCfg: Config = ConfigFactory.parseString(cfgStr)
-      val (_, mc) = Dispatcher.readConfig("example", strCfg)
-      mc.reporter shouldBe empty
+      val (_, reporter) = Dispatcher.readConfig("example", strCfg)
+      reporter shouldBe empty
 
-      val (_, mc2) = Dispatcher.readConfig("example2", strCfg)
-      mc2.reporter shouldBe a[Some[StatsDReporter]]
+      val (_, reporter2) = Dispatcher.readConfig("example2", strCfg)
+      reporter2 shouldBe a[Some[StatsDReporter]]
     }
 
     "override collector settings at the dispatcher level" in {
@@ -297,9 +297,9 @@ class DispatcherSpec extends SpecWithActorSystem {
           """
 
       val strCfg: Config = ConfigFactory.parseString(cfgStr)
-      val (_, mc) = Dispatcher.readConfig("example", strCfg)
-      mc.reporter shouldBe a[Some[StatsDReporter]]
-      mc.reporter.get.asInstanceOf[StatsDReporter].eventSampleRate === 0.7
+      val (_, reporter) = Dispatcher.readConfig("example", strCfg)
+      reporter shouldBe a[Some[StatsDReporter]]
+      reporter.get.asInstanceOf[StatsDReporter].eventSampleRate === 0.7
 
     }
 
@@ -317,8 +317,8 @@ class DispatcherSpec extends SpecWithActorSystem {
             }
           """
 
-      val (_, mc) = Dispatcher.readConfig("example", ConfigFactory.parseString(cfgStr))
-      mc.reporter shouldBe empty
+      val (_, reporter) = Dispatcher.readConfig("example", ConfigFactory.parseString(cfgStr))
+      reporter shouldBe empty
 
     }
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/DurationFunctions.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/DurationFunctions.scala
@@ -1,0 +1,11 @@
+package kanaloa.reactive.dispatcher
+
+import java.time.LocalDateTime
+
+import scala.concurrent.duration.Duration
+
+object DurationFunctions {
+  implicit class DurationExtensions(duration: Duration) {
+    def ago: LocalDateTime = LocalDateTime.now.minusNanos(duration.toNanos)
+  }
+}

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
@@ -357,7 +357,7 @@ object IntegrationTests {
       case msg ⇒
         concurrent += 1
         val overCap = Math.max(concurrent - optimalSize, 0)
-        val wait = baseWait * (1 + Math.pow(overCap, 1.7))
+        val wait = baseWait * (1.0 + Math.pow(overCap, 1.7))
 
         context.actorOf(Props(classOf[Delay])) ! Reply(sender, wait)
     }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
@@ -180,7 +180,7 @@ class AutoScalingWithPushingIntegration extends IntegrationSpec {
             }
             autoScaling {
               chanceOfScalingDownWhenFull = 0.1
-              actionInterval = 100ms
+              scalingInterval = 100ms
               downsizeAfterUnderUtilization = 72h
             }
           }
@@ -239,7 +239,7 @@ class AutoScalingWithPullingIntegration extends IntegrationSpec {
             }
             autoScaling {
               chanceOfScalingDownWhenFull = 0.1
-              actionInterval = 100ms
+              scalingInterval = 100ms
               downsizeAfterUnderUtilization = 72h
             }
           }
@@ -295,7 +295,7 @@ class AutoScalingDownSizeWithSparseTrafficIntegration extends IntegrationSpec {
               minPoolSize = 2
             }
             autoScaling {
-              actionInterval = 10ms
+              scalingInterval = 10ms
               downsizeAfterUnderUtilization = 100ms
             }
           }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
@@ -180,7 +180,7 @@ class AutoScalingWithPushingIntegration extends IntegrationSpec {
             }
             autoScaling {
               chanceOfScalingDownWhenFull = 0.1
-              actionFrequency = 100ms
+              actionInterval = 100ms
               downsizeAfterUnderUtilization = 72h
             }
           }
@@ -227,6 +227,7 @@ class AutoScalingWithPullingIntegration extends IntegrationSpec {
       ConfigFactory.parseString(
         """
           kanaloa.dispatchers.test-pulling {
+            updateInterval = 100ms
             workerPool {
               startingPoolSize = 3
               minPoolSize = 1
@@ -238,7 +239,7 @@ class AutoScalingWithPullingIntegration extends IntegrationSpec {
             }
             autoScaling {
               chanceOfScalingDownWhenFull = 0.1
-              actionFrequency = 100ms
+              actionInterval = 100ms
               downsizeAfterUnderUtilization = 72h
             }
           }
@@ -288,12 +289,13 @@ class AutoScalingDownSizeWithSparseTrafficIntegration extends IntegrationSpec {
       ConfigFactory.parseString(
         """
           kanaloa.dispatchers.test-pushing {
+            updateInterval = 100ms
             workerPool {
               startingPoolSize = 10
               minPoolSize = 2
             }
             autoScaling {
-              actionFrequency = 10ms
+              actionInterval = 10ms
               downsizeAfterUnderUtilization = 100ms
             }
           }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/PerformanceSamplerSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/PerformanceSamplerSpec.scala
@@ -1,37 +1,38 @@
-package kanaloa.reactive.dispatcher.metrics
+package kanaloa.reactive.dispatcher
 
-import akka.actor.{ActorSystem, ActorRef}
-import kanaloa.reactive.dispatcher.SpecWithActorSystem
+import akka.actor.{ActorRef, ActorSystem}
+import kanaloa.reactive.dispatcher.PerformanceSampler._
 import kanaloa.reactive.dispatcher.metrics.Metric._
-import kanaloa.reactive.dispatcher.metrics.MetricsCollector._
+import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, Reporter}
+import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mock.MockitoSugar
-import concurrent.duration._
-import org.mockito.Mockito._
 
-class MetricsCollectorSpec extends SpecWithActorSystem with MockitoSugar with Eventually {
+import scala.concurrent.duration._
+
+class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with Eventually {
   val waitDuration = 30.milliseconds
 
-  def initMetricsCollector(minSampleDurationRatio: Double = 0)(implicit system: ActorSystem): ActorRef = {
-    val mc = system.actorOf(MetricsCollector.props(None, MetricsCollectorSettings(sampleRate = waitDuration / 2, minSampleDurationRatio = minSampleDurationRatio)))
-    mc ! fullyUtilizedResult //set it in the busy mode
-    mc ! PoolSize(10)
-    mc ! Subscribe(self)
-    mc
+  def initPerformanceSampler(minSampleDurationRatio: Double = 0)(implicit system: ActorSystem): ActorRef = {
+    val ps = system.actorOf(MetricsCollector.props(None, PerformanceSamplerSettings(sampleRate = waitDuration / 2, minSampleDurationRatio = minSampleDurationRatio)))
+    ps ! fullyUtilizedResult //set it in the busy mode
+    ps ! PoolSize(10)
+    ps ! Subscribe(self)
+    ps
   }
   val partialUtilizedResult: DispatchResult = DispatchResult(1, 0)
   val fullyUtilizedResult: DispatchResult = DispatchResult(0, 2)
 
-  "MetricsCollector" should {
+  "PerformanceSampler" should {
     "send Samples periodically" in {
-      val mc = initMetricsCollector()
-      mc ! WorkCompleted(1.millisecond)
-      mc ! WorkCompleted(1.millisecond)
+      val ps = initPerformanceSampler()
+      ps ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
 
       val sample1 = expectMsgType[Sample]
       sample1.workDone should be(2)
 
-      mc ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
 
       val sample2 = expectMsgType[Sample]
       sample2.workDone should be(1)
@@ -41,51 +42,51 @@ class MetricsCollectorSpec extends SpecWithActorSystem with MockitoSugar with Ev
     }
 
     "ignore metrics when pool isn't fully occupied" in {
-      val mc = initMetricsCollector()
-      mc ! partialUtilizedResult
+      val ps = initPerformanceSampler()
+      ps ! partialUtilizedResult
       expectMsgType[PartialUtilization].numOfBusyWorkers should be(9)
 
-      mc ! WorkCompleted(1.millisecond)
-      mc ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
 
       expectNoMsg(waitDuration)
 
     }
 
     "ignore Work timeout but include failed Work " in {
-      val mc = initMetricsCollector()
-      mc ! WorkTimedOut
+      val ps = initPerformanceSampler()
+      ps ! WorkTimedOut
       expectNoMsg(waitDuration)
-      mc ! WorkFailed
+      ps ! WorkFailed
       expectMsgType[Sample].workDone should be(1)
     }
 
     "resume to collect metrics once pool becomes busy again, but doesn't count old work" in {
-      val mc = initMetricsCollector()
-      mc ! partialUtilizedResult
+      val ps = initPerformanceSampler()
+      ps ! partialUtilizedResult
 
       expectMsgType[PartialUtilization]
 
-      mc ! WorkCompleted(1.millisecond)
-      mc ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
 
-      mc ! fullyUtilizedResult
+      ps ! fullyUtilizedResult
 
-      mc ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
 
       expectMsgType[Sample].workDone should be(1)
 
     }
 
     "reset counter when pool size changed" in {
-      val mc = initMetricsCollector()
+      val ps = initPerformanceSampler()
 
-      mc ! WorkCompleted(1.millisecond)
-      mc ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
       expectMsgType[Sample].workDone should be(2)
 
-      mc ! PoolSize(12)
-      mc ! WorkCompleted(1.millisecond)
+      ps ! PoolSize(12)
+      ps ! WorkCompleted(1.millisecond)
 
       val sample = expectMsgType[Sample]
       sample.workDone should be(1)
@@ -94,33 +95,33 @@ class MetricsCollectorSpec extends SpecWithActorSystem with MockitoSugar with Ev
     }
 
     "register pool size when resting" in {
-      val mc = initMetricsCollector()
+      val ps = initPerformanceSampler()
 
-      mc ! partialUtilizedResult
+      ps ! partialUtilizedResult
       expectMsgType[PartialUtilization]
 
-      mc ! PoolSize(15)
-      mc ! fullyUtilizedResult
-      mc ! WorkCompleted(1.millisecond)
+      ps ! PoolSize(15)
+      ps ! fullyUtilizedResult
+      ps ! WorkCompleted(1.millisecond)
       expectMsgType[Sample].poolSize should be(15)
 
     }
 
     "continue counting when sample duration not long enough" in {
-      val mc = initMetricsCollector(0.99)
-      mc ! WorkCompleted(1.millisecond)
-      mc ! AddSample
+      val ps = initPerformanceSampler(0.99)
+      ps ! WorkCompleted(1.millisecond)
+      ps ! AddSample
       expectNoMsg(waitDuration / 5)
-      mc ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
       expectMsgType[Sample].workDone should be(2)
     }
 
     "reset counting when pool size changed" in {
-      val mc = initMetricsCollector(0.99)
-      mc ! WorkCompleted(1.millisecond)
-      mc ! PoolSize(15)
+      val ps = initPerformanceSampler(0.99)
+      ps ! WorkCompleted(1.millisecond)
+      ps ! PoolSize(15)
       expectNoMsg(waitDuration / 5)
-      mc ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(1.millisecond)
       val sample = expectMsgType[Sample]
       sample.workDone should be(1)
       sample.poolSize should be(15)
@@ -128,9 +129,9 @@ class MetricsCollectorSpec extends SpecWithActorSystem with MockitoSugar with Ev
 
     "forward metrics to metric reporter" in {
       val reporter = mock[Reporter]
-      val mc = system.actorOf(MetricsCollector.props(Some(reporter)))
+      val p = system.actorOf(MetricsCollector.props(Some(reporter)))
       val ps = PoolSize(3)
-      mc ! ps
+      p ! ps
 
       verify(reporter).report(ps)
     }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/SpecWithActorSystem.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/SpecWithActorSystem.scala
@@ -2,10 +2,11 @@ package kanaloa.reactive.dispatcher
 
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
+import org.scalatest.concurrent.ScaledTimeSpans
 import org.scalatest.{BeforeAndAfterAll, ShouldMatchers, WordSpec, WordSpecLike}
 
 abstract class SpecWithActorSystem(_sys: ActorSystem) extends TestKit(_sys)
-  with ImplicitSender with WordSpecLike with BeforeAndAfterAll with ShouldMatchers {
+  with ImplicitSender with WordSpecLike with BeforeAndAfterAll with ShouldMatchers with ScaledTimeSpans {
 
   def this() = this(ActorSystem("Spec"))
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollectorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollectorSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.concurrent.Eventually._
 class MetricsCollectorSpec extends SpecWithActorSystem {
   val waitDuration = 30.milliseconds
   def initMetricsCollector(minSampleDurationRatio: Double = 0)(implicit system: ActorSystem): ActorRef = {
-    val mc = system.actorOf(MetricsCollector.props(None, Settings(sampleRate = waitDuration / 2, minSampleDurationRatio = minSampleDurationRatio)))
+    val mc = system.actorOf(MetricsCollector.props(None, MetricsCollectorSettings(sampleRate = waitDuration / 2, minSampleDurationRatio = minSampleDurationRatio)))
     mc ! PoolIdle(0)
     mc ! PoolSize(10)
     mc ! Subscribe(self)

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollectorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollectorSpec.scala
@@ -1,0 +1,127 @@
+package kanaloa.reactive.dispatcher.metrics
+
+import akka.actor.{ActorSystem, ActorRef}
+import kanaloa.reactive.dispatcher.SpecWithActorSystem
+import kanaloa.reactive.dispatcher.metrics.Metric._
+import kanaloa.reactive.dispatcher.metrics.MetricsCollector._
+import org.scalatest.time.{Second, Millis, Span}
+import concurrent.duration._
+import org.scalatest.concurrent.Eventually._
+
+class MetricsCollectorSpec extends SpecWithActorSystem {
+  val waitDuration = 30.milliseconds
+  def initMetricsCollector(minSampleDurationRatio: Double = 0)(implicit system: ActorSystem): ActorRef = {
+    val mc = system.actorOf(MetricsCollector.props(None, Settings(sampleRate = waitDuration / 2, minSampleDurationRatio = minSampleDurationRatio)))
+    mc ! PoolIdle(0)
+    mc ! PoolSize(10)
+    mc ! Subscribe(self)
+    mc
+  }
+
+  "MetricsCollector" should {
+    "sample very sample rate" in {
+      val mc = initMetricsCollector()
+      mc ! WorkCompleted
+      mc ! WorkCompleted
+
+      val sample1 = expectMsgType[Sample]
+      sample1.workDone should be(2)
+
+      mc ! WorkCompleted
+
+      val sample2 = expectMsgType[Sample]
+      sample2.workDone should be(1)
+
+      sample2.start.isAfter(sample1.start) should be(true)
+
+    }
+
+    "ignore metrics when pool isn't fully occupied" in {
+      val mc = initMetricsCollector()
+      mc ! PoolIdle(1)
+      expectMsgType[PartialUtilization].numOfBusyWorkers should be(9)
+
+      mc ! WorkCompleted
+      mc ! WorkCompleted
+
+      expectNoMsg(waitDuration)
+
+    }
+
+    "ignore Work timeout but include failed Work " in {
+      val mc = initMetricsCollector()
+      mc ! WorkTimedOut
+      expectNoMsg(waitDuration)
+      mc ! WorkFailed
+      expectMsgType[Sample].workDone should be(1)
+    }
+
+    "resume to collect metrics once pool becomes busy again, but doesn't count old work" in {
+      val mc = initMetricsCollector()
+      mc ! PoolIdle(1)
+
+      expectMsgType[PartialUtilization]
+
+      mc ! WorkCompleted
+      mc ! WorkCompleted
+
+      mc ! PoolIdle(0)
+
+      mc ! WorkCompleted
+
+      expectMsgType[Sample].workDone should be(1)
+
+    }
+
+    "reset counter when pool size changed" in {
+      val mc = initMetricsCollector()
+
+      mc ! WorkCompleted
+      mc ! WorkCompleted
+      expectMsgType[Sample].workDone should be(2)
+
+      mc ! PoolSize(12)
+      mc ! WorkCompleted
+
+      val sample = expectMsgType[Sample]
+      sample.workDone should be(1)
+      sample.poolSize should be(12)
+
+    }
+
+    "register pool size when resting" in {
+      val mc = initMetricsCollector()
+
+      mc ! PoolIdle(1)
+      expectMsgType[PartialUtilization]
+
+      mc ! PoolSize(15)
+      mc ! PoolIdle(0)
+      mc ! WorkCompleted
+      expectMsgType[Sample].poolSize should be(15)
+
+    }
+
+    "continue counting when sample duration not long enough" in {
+      val mc = initMetricsCollector(0.99)
+      mc ! WorkCompleted
+      mc ! AddSample
+      expectNoMsg(waitDuration / 5)
+      mc ! WorkCompleted
+      expectMsgType[Sample].workDone should be(2)
+    }
+
+    "reset counting when pool size changed" in {
+      val mc = initMetricsCollector(0.99)
+      mc ! WorkCompleted
+      mc ! PoolSize(15)
+      expectNoMsg(waitDuration / 5)
+      mc ! WorkCompleted
+      val sample = expectMsgType[Sample]
+      sample.workDone should be(1)
+      sample.poolSize should be(15)
+    }
+
+  }
+
+}

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollectorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/metrics/MetricsCollectorSpec.scala
@@ -4,30 +4,34 @@ import akka.actor.{ActorSystem, ActorRef}
 import kanaloa.reactive.dispatcher.SpecWithActorSystem
 import kanaloa.reactive.dispatcher.metrics.Metric._
 import kanaloa.reactive.dispatcher.metrics.MetricsCollector._
-import org.scalatest.time.{Second, Millis, Span}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.mock.MockitoSugar
 import concurrent.duration._
-import org.scalatest.concurrent.Eventually._
+import org.mockito.Mockito._
 
-class MetricsCollectorSpec extends SpecWithActorSystem {
+class MetricsCollectorSpec extends SpecWithActorSystem with MockitoSugar with Eventually {
   val waitDuration = 30.milliseconds
+
   def initMetricsCollector(minSampleDurationRatio: Double = 0)(implicit system: ActorSystem): ActorRef = {
     val mc = system.actorOf(MetricsCollector.props(None, MetricsCollectorSettings(sampleRate = waitDuration / 2, minSampleDurationRatio = minSampleDurationRatio)))
-    mc ! PoolIdle(0)
+    mc ! fullyUtilizedResult //set it in the busy mode
     mc ! PoolSize(10)
     mc ! Subscribe(self)
     mc
   }
+  val partialUtilizedResult: DispatchResult = DispatchResult(1, 0)
+  val fullyUtilizedResult: DispatchResult = DispatchResult(0, 2)
 
   "MetricsCollector" should {
-    "sample very sample rate" in {
+    "send Samples periodically" in {
       val mc = initMetricsCollector()
-      mc ! WorkCompleted
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
+      mc ! WorkCompleted(1.millisecond)
 
       val sample1 = expectMsgType[Sample]
       sample1.workDone should be(2)
 
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
 
       val sample2 = expectMsgType[Sample]
       sample2.workDone should be(1)
@@ -38,11 +42,11 @@ class MetricsCollectorSpec extends SpecWithActorSystem {
 
     "ignore metrics when pool isn't fully occupied" in {
       val mc = initMetricsCollector()
-      mc ! PoolIdle(1)
+      mc ! partialUtilizedResult
       expectMsgType[PartialUtilization].numOfBusyWorkers should be(9)
 
-      mc ! WorkCompleted
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
+      mc ! WorkCompleted(1.millisecond)
 
       expectNoMsg(waitDuration)
 
@@ -58,16 +62,16 @@ class MetricsCollectorSpec extends SpecWithActorSystem {
 
     "resume to collect metrics once pool becomes busy again, but doesn't count old work" in {
       val mc = initMetricsCollector()
-      mc ! PoolIdle(1)
+      mc ! partialUtilizedResult
 
       expectMsgType[PartialUtilization]
 
-      mc ! WorkCompleted
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
+      mc ! WorkCompleted(1.millisecond)
 
-      mc ! PoolIdle(0)
+      mc ! fullyUtilizedResult
 
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
 
       expectMsgType[Sample].workDone should be(1)
 
@@ -76,12 +80,12 @@ class MetricsCollectorSpec extends SpecWithActorSystem {
     "reset counter when pool size changed" in {
       val mc = initMetricsCollector()
 
-      mc ! WorkCompleted
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
+      mc ! WorkCompleted(1.millisecond)
       expectMsgType[Sample].workDone should be(2)
 
       mc ! PoolSize(12)
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
 
       val sample = expectMsgType[Sample]
       sample.workDone should be(1)
@@ -92,34 +96,59 @@ class MetricsCollectorSpec extends SpecWithActorSystem {
     "register pool size when resting" in {
       val mc = initMetricsCollector()
 
-      mc ! PoolIdle(1)
+      mc ! partialUtilizedResult
       expectMsgType[PartialUtilization]
 
       mc ! PoolSize(15)
-      mc ! PoolIdle(0)
-      mc ! WorkCompleted
+      mc ! fullyUtilizedResult
+      mc ! WorkCompleted(1.millisecond)
       expectMsgType[Sample].poolSize should be(15)
 
     }
 
     "continue counting when sample duration not long enough" in {
       val mc = initMetricsCollector(0.99)
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
       mc ! AddSample
       expectNoMsg(waitDuration / 5)
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
       expectMsgType[Sample].workDone should be(2)
     }
 
     "reset counting when pool size changed" in {
       val mc = initMetricsCollector(0.99)
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
       mc ! PoolSize(15)
       expectNoMsg(waitDuration / 5)
-      mc ! WorkCompleted
+      mc ! WorkCompleted(1.millisecond)
       val sample = expectMsgType[Sample]
       sample.workDone should be(1)
       sample.poolSize should be(15)
+    }
+
+    "forward metrics to metric reporter" in {
+      val reporter = mock[Reporter]
+      val mc = system.actorOf(MetricsCollector.props(Some(reporter)))
+      val ps = PoolSize(3)
+      mc ! ps
+
+      verify(reporter).report(ps)
+    }
+
+    "report utilization even when fully utilized" in {
+      val reporter = mock[Reporter]
+      val mc = system.actorOf(MetricsCollector.props(Some(reporter)))
+
+      mc ! PoolSize(4)
+      mc ! fullyUtilizedResult
+
+      mc ! AddSample
+
+      eventually {
+        verify(reporter).report(PoolSize(4))
+        verify(reporter).report(PoolUtilized(4))
+      }
+
     }
 
   }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
@@ -6,7 +6,7 @@ import akka.actor.{ActorRef, ActorSystem, PoisonPill}
 import akka.testkit._
 import kanaloa.reactive.dispatcher.ApiProtocol.QueryStatus
 import kanaloa.reactive.dispatcher.{ResultChecker, ScopeWithActor, SpecWithActorSystem}
-import kanaloa.reactive.dispatcher.metrics.{Metric, MetricsCollector, NoOpMetricsCollector}
+import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, Metric}
 import kanaloa.reactive.dispatcher.queue.AutoScaling.{OptimizeOrExplore, PoolSize, UnderUtilizationStreak}
 import kanaloa.reactive.dispatcher.queue.Queue.{QueueDispatchInfo, Retire}
 import kanaloa.reactive.dispatcher.queue.QueueProcessor.{RunningStatus, ScaleTo, Shutdown}
@@ -223,7 +223,7 @@ class AutoScalingSpec extends SpecWithActorSystem with MockitoSugar with OptionV
 class AutoScalingScope(implicit system: ActorSystem)
   extends TestKit(system) with ImplicitSender {
 
-  val metricsCollector: MetricsCollector = NoOpMetricsCollector // To be overridden
+  val metricsCollector: MetricsCollector = new MetricsCollector(None) // To be overridden
 
   val tQueue = TestProbe()
   val tProcessor = TestProbe()

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
@@ -14,12 +14,10 @@ import kanaloa.reactive.dispatcher.queue.QueueProcessor.{RunningStatus, ScaleTo,
 import kanaloa.reactive.dispatcher.queue.Worker.{Idle, Working}
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mock.MockitoSugar
-import org.mockito.Mockito._
 import kanaloa.reactive.dispatcher.DurationFunctions._
 import scala.concurrent.duration._
 
-class AutoScalingSpec extends SpecWithActorSystem with MockitoSugar with OptionValues with Eventually {
+class AutoScalingSpec extends SpecWithActorSystem with OptionValues with Eventually {
   import AutoScalingScope._
 
   "AutoScaling" should {
@@ -185,7 +183,7 @@ class AutoScalingSpec extends SpecWithActorSystem with MockitoSugar with OptionV
       val queue = TestProbe()
       val processor = system.actorOf(QueueProcessor.default(queue.ref, backend, ProcessingWorkerPoolSettings(), mc)(ResultChecker.simple))
       //using 10 minutes to squelch its querying of the QueueProcessor, so that we can do it manually
-      val a = system.actorOf(AutoScaling.default(processor, AutoScalingSettings(actionInterval = 10.minutes), mc))
+      val a = system.actorOf(AutoScaling.default(processor, AutoScalingSettings(scalingInterval = 10.minutes), mc))
       watch(a)
       a ! PartialUtilization(5)
       processor ! Shutdown(None, 100.milliseconds, false)
@@ -200,7 +198,7 @@ class AutoScalingScope(implicit system: ActorSystem)
   val metricsCollector: ActorRef = MetricsCollector(None) // To be overridden
   val defaultSettings: AutoScalingSettings = AutoScalingSettings(
     chanceOfScalingDownWhenFull = 0.3,
-    actionInterval = 1.hour, //manual action only
+    scalingInterval = 1.hour, //manual action only
     explorationRatio = 0.5,
     downsizeRatio = 0.8,
     downsizeAfterUnderUtilization = 72.hours,

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
@@ -5,9 +5,10 @@ import java.time.LocalDateTime
 import akka.actor.{ActorRef, ActorSystem, PoisonPill}
 import akka.testkit._
 import kanaloa.reactive.dispatcher.ApiProtocol.QueryStatus
+import kanaloa.reactive.dispatcher.metrics.MetricsCollector.{PartialUtilization, Sample}
 import kanaloa.reactive.dispatcher.{ResultChecker, ScopeWithActor, SpecWithActorSystem}
 import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, Metric}
-import kanaloa.reactive.dispatcher.queue.AutoScaling.{OptimizeOrExplore, PoolSize, UnderUtilizationStreak}
+import kanaloa.reactive.dispatcher.queue.AutoScaling.{AutoScalingStatus, OptimizeOrExplore, PoolSize}
 import kanaloa.reactive.dispatcher.queue.Queue.{QueueDispatchInfo, Retire}
 import kanaloa.reactive.dispatcher.queue.QueueProcessor.{RunningStatus, ScaleTo, Shutdown}
 import kanaloa.reactive.dispatcher.queue.Worker.{Idle, Working}
@@ -15,7 +16,7 @@ import org.scalatest.OptionValues
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
-
+import kanaloa.reactive.dispatcher.DurationFunctions._
 import scala.concurrent.duration._
 
 class AutoScalingSpec extends SpecWithActorSystem with MockitoSugar with OptionValues with Eventually {
@@ -24,71 +25,71 @@ class AutoScalingSpec extends SpecWithActorSystem with MockitoSugar with OptionV
   "AutoScaling" should {
     "when no history" in new AutoScalingScope {
       as ! OptimizeOrExplore
-      tQueue.expectMsgType[QueryStatus]
-      tQueue.reply(MockQueueInfo(None))
-      tProcessor.expectMsgType[QueryStatus]
-    }
-
-    "send metrics to metricsCollector" in new AutoScalingScope {
-      val mcProbe = TestProbe()
-      override val metricsCollector: ActorRef = mcProbe.ref
-      val mc = metricsCollector
-
-      as ! OptimizeOrExplore
-
-      replyStatus(
-        numOfBusyWorkers = 3,
-        numOfIdleWorkers = 1
-      )
-      mcProbe.expectMsg(Metric.PoolSize(4))
-      mcProbe.expectMsg(Metric.PoolUtilized(3))
-      mcProbe.expectNoMsg()
+      tProcessor.expectNoMsg(50.milliseconds)
     }
 
     "record perfLog" in new AutoScalingScope {
-      as ! OptimizeOrExplore
-      tQueue.expectMsgType[QueryStatus]
-      tQueue.reply(MockQueueInfo(Some(1.second)))
-      tProcessor.expectMsgType[QueryStatus]
-      tProcessor.reply(RunningStatus(Set(newWorker(), newWorker())))
-      tProcessor.expectMsgType[ScaleTo]
-      as.underlyingActor.perfLog should not be empty
+      as ! Sample(3, 2.second.ago, 1.second.ago, 30)
+      as ! QueryStatus()
+      val status = expectMsgType[AutoScalingStatus]
+      status.poolSize should contain(30)
+      status.performanceLog.keys should contain(30)
+    }
+
+    "update poolsize" in new AutoScalingScope {
+      as ! Sample(3, 2.second.ago, 1.second.ago, 30)
+      as ! Sample(3, 2.second.ago, 1.second.ago, 33)
+      as ! Sample(3, 2.second.ago, 1.second.ago, 35)
+      as ! QueryStatus()
+      val status = expectMsgType[AutoScalingStatus]
+      status.poolSize should contain(35)
+      status.performanceLog.keys should contain(33)
     }
 
     "start an underutilizationStreak" in new AutoScalingScope {
-      as ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 3, numOfIdleWorkers = 1)
-      tProcessor.expectNoMsg(15.millisecond)
-      as.underlyingActor.underUtilizationStreak.get.highestUtilization === 3
+      as ! PartialUtilization(3)
+      as ! QueryStatus()
+      val status = expectMsgType[AutoScalingStatus]
+      status.partialUtilization should contain(3)
+      status.partialUtilizationStart should not be (empty)
     }
 
     "stop an underutilizationStreak" in new AutoScalingScope {
-      as ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 3, numOfIdleWorkers = 1)
-      tProcessor.expectNoMsg(15.millisecond)
-      as ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 4, numOfIdleWorkers = 0)
-      expectNoMsg(15.millisecond) //wait
-      as.underlyingActor.underUtilizationStreak shouldBe empty
+      as ! PartialUtilization(3)
+      as ! Sample(3, 2.second.ago, 1.second.ago, 30)
+
+      as ! QueryStatus()
+      val status = expectMsgType[AutoScalingStatus]
+      status.partialUtilization should be(empty)
+      status.partialUtilizationStart should be(empty)
     }
 
-    "update an underutilizationStreak" in new AutoScalingScope {
-      as ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 3, numOfIdleWorkers = 1)
-      tProcessor.expectNoMsg(50.millisecond)
-      val start = as.underlyingActor.underUtilizationStreak.get.start
-      as ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 5, numOfIdleWorkers = 1)
+    "update an underutilizationStreak to the highest utilization" in new AutoScalingScope {
+      as ! PartialUtilization(3)
+      as ! QueryStatus()
 
-      tProcessor.expectNoMsg(15.millisecond)
-      as.underlyingActor.underUtilizationStreak.get.start === start
-      as.underlyingActor.underUtilizationStreak.get.highestUtilization === 5
+      val status1 = expectMsgType[AutoScalingStatus]
+
+      as ! PartialUtilization(5)
+      as ! QueryStatus()
+
+      val status2 = expectMsgType[AutoScalingStatus]
+
+      as ! PartialUtilization(4)
+      as ! QueryStatus()
+
+      val status3 = expectMsgType[AutoScalingStatus]
+
+      status1.partialUtilizationStart should not be (empty)
+      status1.partialUtilizationStart should be(status3.partialUtilizationStart)
+      status3.partialUtilization should contain(5)
     }
 
     "explore when currently maxed out and exploration rate is 1" in new AutoScalingScope {
-      val subject = autoScalingRef(explorationRatio = 1)
+      val subject = autoScalingRef(alwaysExploreSettings)
+      subject ! Sample(3, 2.second.ago, 1.second.ago, 30)
+
       subject ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 3, numOfIdleWorkers = 0)
 
       val scaleCmd = tProcessor.expectMsgType[ScaleTo]
 
@@ -96,98 +97,70 @@ class AutoScalingSpec extends SpecWithActorSystem with MockitoSugar with OptionV
     }
 
     "does not optimize when not currently maxed" in new AutoScalingScope {
-      val subject = autoScalingRef(explorationRatio = 1)
+      val subject = autoScalingRef()
+      subject ! Sample(3, 2.second.ago, 1.second.ago, 30)
+
       subject ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 3, numOfIdleWorkers = 0)
       tProcessor.expectMsgType[ScaleTo]
+
+      subject ! PartialUtilization(4)
+
       subject ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 3, numOfIdleWorkers = 1)
+
       tProcessor.expectNoMsg(30.millisecond)
     }
 
     "optimize towards the faster size when currently maxed out and exploration rate is 0" in new AutoScalingScope {
-      val subject = autoScalingRef(explorationRatio = 0)
+      val subject = autoScalingRef(alwaysOptimizeSettings)
       mockBusyHistory(
         subject,
-        (30, 32.milliseconds),
-        (30, 30.milliseconds),
-        (40, 20.milliseconds),
-        (40, 23.milliseconds),
-        (35, 25.milliseconds)
+        (30, 3),
+        (35, 4),
+        (40, 9),
+        (40, 8),
+        (45, 4)
       )
       subject ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 32, numOfIdleWorkers = 0, dispatchDuration = 43.milliseconds)
       val scaleCmd = tProcessor.expectMsgType[ScaleTo]
 
       scaleCmd.reason.value shouldBe "optimizing"
       scaleCmd.numOfWorkers should be > 35
-      scaleCmd.numOfWorkers should be < 40
+      scaleCmd.numOfWorkers should be < 45
     }
 
     "ignore further away sample data when optmizing" in new AutoScalingScope {
-      val subject = autoScalingRef(explorationRatio = 0)
+      val subject = autoScalingRef(alwaysOptimizeSettings)
       mockBusyHistory(
         subject,
-        (10, 1.milliseconds), //should be ignored
-        (29, 32.milliseconds),
-        (31, 32.milliseconds),
-        (32, 32.milliseconds),
-        (35, 32.milliseconds),
-        (36, 32.milliseconds),
-        (31, 30.milliseconds),
-        (43, 20.milliseconds),
-        (41, 23.milliseconds),
-        (37, 25.milliseconds)
+        (10, 1999), //should be ignored
+        (29, 2),
+        (31, 2),
+        (32, 2),
+        (35, 3),
+        (36, 3),
+        (31, 3),
+        (46, 4),
+        (41, 8),
+        (37, 6)
       )
       subject ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 37, numOfIdleWorkers = 0, dispatchDuration = 28.milliseconds)
+
       val scaleCmd = tProcessor.expectMsgType[ScaleTo]
 
       scaleCmd.reason.value shouldBe "optimizing"
       scaleCmd.numOfWorkers should be > 35
-      scaleCmd.numOfWorkers should be < 43
-    }
-
-    "do nothing if not enough history in general " in new AutoScalingScope {
-      val subject = autoScalingRef(explorationRatio = 1)
-      subject ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 3, numOfIdleWorkers = 1)
-
-      tProcessor.expectNoMsg(20.milliseconds)
-      subject ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 3, numOfIdleWorkers = 1)
-
-      tProcessor.expectNoMsg(50.milliseconds)
+      scaleCmd.numOfWorkers should be < 44
     }
 
     "downsize if hasn't maxed out for more than relevant period of hours" in new AutoScalingScope {
-      val moreThan72HoursAgo = LocalDateTime.now.minusHours(73)
-      as.underlyingActor.underUtilizationStreak = Some(UnderUtilizationStreak(moreThan72HoursAgo, 40))
+      val subject = autoScalingRef(defaultSettings.copy(downsizeAfterUnderUtilization = 10.milliseconds))
 
-      as ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 34, numOfIdleWorkers = 16)
+      subject ! PartialUtilization(5)
+      tProcessor.expectNoMsg(20.milliseconds)
+      subject ! OptimizeOrExplore
+
       val scaleCmd = tProcessor.expectMsgType[ScaleTo]
-      scaleCmd shouldBe ScaleTo(32, Some("downsizing"))
-    }
-
-    "do not thing if hasn't maxed out for shorter than relevant period of hours" in new AutoScalingScope {
-      val lessThan72HoursAgo = LocalDateTime.now.minusHours(71)
-      as.underlyingActor.underUtilizationStreak = Some(UnderUtilizationStreak(lessThan72HoursAgo, 40))
-
-      as ! OptimizeOrExplore
-      replyStatus(numOfBusyWorkers = 34, numOfIdleWorkers = 16)
-      tProcessor.expectNoMsg(50.millis)
-    }
-
-    "stop itself if the Queue stops" in new AutoScalingScope {
-      val queue = system.actorOf(Queue.default(metricsCollector))
-      watch(queue)
-      val processor = TestProbe()
-      val a = system.actorOf(AutoScaling.default(queue, processor.ref, AutoScalingSettings(), metricsCollector))
-      watch(a)
-      queue ! Retire(1.millisecond)
-      expectTerminated(queue)
-      expectTerminated(a)
+      scaleCmd shouldBe ScaleTo(4, Some("downsizing"))
     }
 
     "stop itself if the QueueProcessor stops" in new ScopeWithActor() {
@@ -197,12 +170,10 @@ class AutoScalingSpec extends SpecWithActorSystem with MockitoSugar with OptionV
         backend,
         ProcessingWorkerPoolSettings(),
         MetricsCollector(None)
-      )(
-          ResultChecker.simple
-        ))
+      )(ResultChecker.simple))
 
       watch(processor)
-      val a = system.actorOf(AutoScaling.default(queue.ref, processor, AutoScalingSettings(), MetricsCollector(None)))
+      val a = system.actorOf(AutoScaling.default(processor, AutoScalingSettings(), MetricsCollector(None)))
       watch(a)
       processor ! PoisonPill
       expectTerminated(processor)
@@ -213,16 +184,12 @@ class AutoScalingSpec extends SpecWithActorSystem with MockitoSugar with OptionV
       val mc = MetricsCollector(None)
       val queue = TestProbe()
       val processor = system.actorOf(QueueProcessor.default(queue.ref, backend, ProcessingWorkerPoolSettings(), mc)(ResultChecker.simple))
-      watch(processor)
       //using 10 minutes to squelch its querying of the QueueProcessor, so that we can do it manually
-      val a = system.actorOf(AutoScaling.default(queue.ref, processor, AutoScalingSettings(actionFrequency = 10.minutes), mc))
+      val a = system.actorOf(AutoScaling.default(processor, AutoScalingSettings(actionInterval = 10.minutes), mc))
       watch(a)
-      //let this thing take its sweet time shutting down
+      a ! PartialUtilization(5)
       processor ! Shutdown(None, 100.milliseconds, false)
-      a ! OptimizeOrExplore
-      a ! kanaloa.reactive.dispatcher.queue.Queue.QueueStatus()
       expectTerminated(a)
-      expectTerminated(processor)
     }
   }
 }
@@ -231,39 +198,39 @@ class AutoScalingScope(implicit system: ActorSystem)
   extends TestKit(system) with ImplicitSender {
 
   val metricsCollector: ActorRef = MetricsCollector(None) // To be overridden
+  val defaultSettings: AutoScalingSettings = AutoScalingSettings(
+    chanceOfScalingDownWhenFull = 0.3,
+    actionInterval = 1.hour, //manual action only
+    explorationRatio = 0.5,
+    downsizeRatio = 0.8,
+    downsizeAfterUnderUtilization = 72.hours,
+    numOfAdjacentSizesToConsiderDuringOptimization = 6
+  )
 
-  val tQueue = TestProbe()
+  val alwaysOptimizeSettings = defaultSettings.copy(explorationRatio = 0)
+  val alwaysExploreSettings = defaultSettings.copy(explorationRatio = 1)
+
   val tProcessor = TestProbe()
-  import AutoScalingScope._
 
-  def autoScalingRef(explorationRatio: Double = 0.5) =
-    TestActorRef[AutoScaling](AutoScaling.default(tQueue.ref, tProcessor.ref,
-      AutoScalingSettings(
-        chanceOfScalingDownWhenFull = 0.3,
-        actionFrequency = 1.hour, //manual action only
-        explorationRatio = explorationRatio,
-        downsizeRatio = 0.8,
-        numOfAdjacentSizesToConsiderDuringOptimization = 6
-      ), metricsCollector))
+  def autoScalingRef(settings: AutoScalingSettings = defaultSettings) = {
 
-  def replyStatus(numOfBusyWorkers: Int, dispatchDuration: Duration = 5.milliseconds, numOfIdleWorkers: Int = 0): Unit = {
-    tQueue.expectMsgType[QueryStatus]
-    val fullyUtilized = numOfIdleWorkers == 0
-    tQueue.reply(MockQueueInfo(if (fullyUtilized) Some(dispatchDuration) else None))
-
-    tProcessor.expectMsgType[QueryStatus]
-    val workers = (1 to numOfBusyWorkers).map(_ ⇒ newWorker(true)) ++
-      (1 to numOfIdleWorkers).map(_ ⇒ newWorker(false))
-    tProcessor.reply(RunningStatus(workers.toSet))
-
+    TestActorRef[AutoScaling](AutoScaling.default(
+      tProcessor.ref, settings, metricsCollector
+    ))
   }
 
-  def mockBusyHistory(subject: ActorRef, ps: (PoolSize, Duration)*) = {
-    ps.foreach {
-      case (size, duration) ⇒
-        subject ! OptimizeOrExplore
-        replyStatus(numOfBusyWorkers = size, dispatchDuration = duration)
-        tProcessor.expectMsgType[ScaleTo]
+  def mockBusyHistory(subject: ActorRef, ps: (PoolSize, Int)*) = {
+
+    ps.zipWithIndex.foreach {
+      case ((size, workDone), idx) ⇒
+        val distance = ps.size - idx + 1
+
+        subject ! Sample(
+          workDone,
+          start = distance.seconds.ago,
+          end = (distance - 1).seconds.ago,
+          size
+        )
     }
 
   }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 import akka.actor.{ActorRef, ActorSystem, PoisonPill}
 import akka.testkit._
 import kanaloa.reactive.dispatcher.ApiProtocol.QueryStatus
-import kanaloa.reactive.dispatcher.metrics.MetricsCollector.{PartialUtilization, Sample}
+import kanaloa.reactive.dispatcher.PerformanceSampler.{PartialUtilization, Sample}
 import kanaloa.reactive.dispatcher.{ResultChecker, ScopeWithActor, SpecWithActorSystem}
 import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, Metric}
 import kanaloa.reactive.dispatcher.queue.AutoScaling.{AutoScalingStatus, OptimizeOrExplore, PoolSize}

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
@@ -266,7 +266,7 @@ class AutoScalingScope(implicit system: ActorSystem)
 
 object AutoScalingScope {
   import akka.actor.ActorDSL._
-  case class MockQueueInfo(avgDispatchDurationLowerBoundWhenFullyUtilized: Option[Duration]) extends QueueDispatchInfo
+  case class MockQueueInfo(avgDequeueDurationLowerBoundWhenFullyUtilized: Option[Duration]) extends QueueDispatchInfo
 
   def newWorker(busy: Boolean = true)(implicit system: ActorSystem) = actor(new Act {
     become {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
@@ -3,7 +3,6 @@ package kanaloa.reactive.dispatcher.queue
 import akka.actor._
 import akka.testkit.{TestActorRef, TestProbe}
 import kanaloa.reactive.dispatcher.ApiProtocol.{QueryStatus, ShutdownSuccessfully}
-import kanaloa.reactive.dispatcher.metrics.Metric.ProcessTime
 import kanaloa.reactive.dispatcher.metrics.{Reporter, Metric, MetricsCollector}
 import kanaloa.reactive.dispatcher.queue.Queue._
 import kanaloa.reactive.dispatcher.queue.QueueProcessor.{Shutdown, _}
@@ -384,8 +383,8 @@ class QueueMetricsSpec extends SpecWithActorSystem {
       queue ! Enqueue("d")
       delegatee.expectMsg("d")
 
-      receivedMetrics should contain allOf (Metric.WorkCompleted, Metric.WorkFailed, Metric.WorkTimedOut)
-      receivedMetrics.collect { case x: ProcessTime ⇒ x } should have size 1
+      receivedMetrics should contain allOf (Metric.WorkFailed, Metric.WorkTimedOut)
+      receivedMetrics.collect { case x: Metric.WorkCompleted ⇒ x } should have size 1
     }
   }
 }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
@@ -391,7 +391,7 @@ class QueueMetricsSpec extends SpecWithActorSystem {
 }
 
 class QueueScope(implicit system: ActorSystem) extends ScopeWithQueue {
-  val metricsCollector: MetricsCollector = new MetricsCollector(None) // To be overridden
+  val metricsCollector: MetricsCollector = MetricsCollector(None) // To be overridden
 
   def queueProcessorWithCBProps(queue: QueueRef, circuitBreakerSettings: CircuitBreakerSettings) =
     QueueProcessor.withCircuitBreaker(queue, backend, ProcessingWorkerPoolSettings(startingPoolSize = 1), circuitBreakerSettings, metricsCollector) {
@@ -421,13 +421,13 @@ class QueueScope(implicit system: ActorSystem) extends ScopeWithQueue {
     historySettings: DispatchHistorySettings = DispatchHistorySettings()
   ): QueueRef =
     system.actorOf(
-      iteratorQueueProps(iterator, historySettings, workSetting, sendResultsTo, metricsCollector),
+      iteratorQueueProps(iterator, metricsCollector, historySettings, workSetting, sendResultsTo),
       "iterator-queue-" + Random.nextInt(100000)
     )
 
   def defaultQueue(workSetting: WorkSettings = WorkSettings(), historySettings: DispatchHistorySettings = DispatchHistorySettings()): QueueRef =
     system.actorOf(
-      Queue.default(historySettings, workSetting, metricsCollector),
+      Queue.default(metricsCollector, historySettings, workSetting),
       "default-queue-" + Random.nextInt(100000)
     )
 
@@ -436,7 +436,7 @@ class QueueScope(implicit system: ActorSystem) extends ScopeWithQueue {
     defaultWorkSetting:  WorkSettings            = WorkSettings(),
     historySettings:     DispatchHistorySettings = DispatchHistorySettings()
   ) = system.actorOf(
-    Queue.withBackPressure(historySettings, backPressureSetting, defaultWorkSetting, metricsCollector),
+    Queue.withBackPressure(historySettings, backPressureSetting, metricsCollector, defaultWorkSetting),
     "with-back-pressure-queue" + Random.nextInt(500000)
   )
 }
@@ -445,7 +445,7 @@ class MetricCollectorScope(implicit system: ActorSystem) extends QueueScope {
   @volatile
   var receivedMetrics: List[Metric] = Nil
 
-  override val metricsCollector: MetricsCollector = new MetricsCollector(Some(new Reporter {
+  override val metricsCollector: MetricsCollector = MetricsCollector(Some(new Reporter {
     def report(metric: Metric): Unit = receivedMetrics = metric :: receivedMetrics
   }))
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
@@ -391,7 +391,7 @@ class QueueMetricsSpec extends SpecWithActorSystem {
 }
 
 class QueueScope(implicit system: ActorSystem) extends ScopeWithQueue {
-  val metricsCollector: MetricsCollector = MetricsCollector(None) // To be overridden
+  val metricsCollector: ActorRef = MetricsCollector(None) // To be overridden
 
   def queueProcessorWithCBProps(queue: QueueRef, circuitBreakerSettings: CircuitBreakerSettings) =
     QueueProcessor.withCircuitBreaker(queue, backend, ProcessingWorkerPoolSettings(startingPoolSize = 1), circuitBreakerSettings, metricsCollector) {
@@ -445,7 +445,7 @@ class MetricCollectorScope(implicit system: ActorSystem) extends QueueScope {
   @volatile
   var receivedMetrics: List[Metric] = Nil
 
-  override val metricsCollector: MetricsCollector = MetricsCollector(Some(new Reporter {
+  override val metricsCollector: ActorRef = MetricsCollector(Some(new Reporter {
     def report(metric: Metric): Unit = receivedMetrics = metric :: receivedMetrics
   }))
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueWithBackPressureSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueWithBackPressureSpec.scala
@@ -7,6 +7,7 @@ import akka.actor._
 import akka.testkit.TestActorRef
 import kanaloa.reactive.dispatcher.ApiProtocol._
 import kanaloa.reactive.dispatcher.SpecWithActorSystem
+import kanaloa.reactive.dispatcher.metrics.MetricsCollector
 import kanaloa.reactive.dispatcher.queue.Queue._
 import kanaloa.reactive.dispatcher.queue.TestUtils._
 
@@ -69,7 +70,8 @@ class QueueWithBackPressureSpec extends SpecWithActorSystem {
       BackPressureSettings(
         maxBufferSize = 10,
         thresholdForExpectedWaitTime = 5.minutes
-      )
+      ),
+      MetricsCollector(None)
     )).underlyingActor
 
     def status(stats: (Int, Int, Int, LocalDateTime)*): QueueStatus =

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/TestUtils.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/TestUtils.scala
@@ -18,12 +18,12 @@ object TestUtils {
 
   def iteratorQueueProps(
     iterator:         Iterator[String],
+    metricsCollector: MetricsCollector,
     historySettings:  DispatchHistorySettings = DispatchHistorySettings(),
     workSetting:      WorkSettings            = WorkSettings(),
-    sendResultsTo:    Option[ActorRef]        = None,
-    metricsCollector: MetricsCollector        = new MetricsCollector(None)
+    sendResultsTo:    Option[ActorRef]        = None
   ): Props =
-    Queue.ofIterator(iterator.map(DelegateeMessage(_)), historySettings, workSetting, sendResultsTo, metricsCollector)
+    Queue.ofIterator(iterator.map(DelegateeMessage(_)), historySettings, metricsCollector, workSetting, sendResultsTo)
 
   class ScopeWithQueue(implicit system: ActorSystem) extends TestKit(system) with ImplicitSender {
 
@@ -34,7 +34,7 @@ object TestUtils {
     def defaultProcessorProps(
       queue:            QueueRef,
       settings:         ProcessingWorkerPoolSettings = ProcessingWorkerPoolSettings(startingPoolSize = 1),
-      metricsCollector: MetricsCollector             = new MetricsCollector(None)
+      metricsCollector: MetricsCollector             = MetricsCollector(None)
     ) = QueueProcessor.default(queue, backend, settings, metricsCollector)(resultChecker)
   }
 }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/TestUtils.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/TestUtils.scala
@@ -18,7 +18,7 @@ object TestUtils {
 
   def iteratorQueueProps(
     iterator:         Iterator[String],
-    metricsCollector: MetricsCollector,
+    metricsCollector: ActorRef,
     historySettings:  DispatchHistorySettings = DispatchHistorySettings(),
     workSetting:      WorkSettings            = WorkSettings(),
     sendResultsTo:    Option[ActorRef]        = None
@@ -34,7 +34,7 @@ object TestUtils {
     def defaultProcessorProps(
       queue:            QueueRef,
       settings:         ProcessingWorkerPoolSettings = ProcessingWorkerPoolSettings(startingPoolSize = 1),
-      metricsCollector: MetricsCollector             = MetricsCollector(None)
+      metricsCollector: ActorRef                     = MetricsCollector(None)
     ) = QueueProcessor.default(queue, backend, settings, metricsCollector)(resultChecker)
   }
 }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/TestUtils.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/TestUtils.scala
@@ -3,7 +3,7 @@ package kanaloa.reactive.dispatcher.queue
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import kanaloa.reactive.dispatcher._
-import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, NoOpMetricsCollector}
+import kanaloa.reactive.dispatcher.metrics.MetricsCollector
 
 object TestUtils {
 
@@ -21,7 +21,7 @@ object TestUtils {
     historySettings:  DispatchHistorySettings = DispatchHistorySettings(),
     workSetting:      WorkSettings            = WorkSettings(),
     sendResultsTo:    Option[ActorRef]        = None,
-    metricsCollector: MetricsCollector        = NoOpMetricsCollector
+    metricsCollector: MetricsCollector        = new MetricsCollector(None)
   ): Props =
     Queue.ofIterator(iterator.map(DelegateeMessage(_)), historySettings, workSetting, sendResultsTo, metricsCollector)
 
@@ -34,7 +34,7 @@ object TestUtils {
     def defaultProcessorProps(
       queue:            QueueRef,
       settings:         ProcessingWorkerPoolSettings = ProcessingWorkerPoolSettings(startingPoolSize = 1),
-      metricsCollector: MetricsCollector             = NoOpMetricsCollector
+      metricsCollector: MetricsCollector             = new MetricsCollector(None)
     ) = QueueProcessor.default(queue, backend, settings, metricsCollector)(resultChecker)
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,11 +4,12 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akka = "2.4.7"
+    val akka = "2.4.8"
   }
 
   val akka = Seq(
     "com.typesafe.akka" %% "akka-actor" % Versions.akka,
+    "com.typesafe.akka" %% "akka-agent" % Versions.akka,
     "com.typesafe.akka" %% "akka-testkit" % Versions.akka % "test",
     "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.akka % "test",
     "com.typesafe.akka" %% "akka-slf4j" % Versions.akka
@@ -30,6 +31,7 @@ object Dependencies {
   val config = Seq(
     "com.iheart" %% "ficus" % "1.2.6"
   )
+
 
   lazy val settings = Seq(
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,6 @@ object Dependencies {
 
   val akka = Seq(
     "com.typesafe.akka" %% "akka-actor" % Versions.akka,
-    "com.typesafe.akka" %% "akka-agent" % Versions.akka,
     "com.typesafe.akka" %% "akka-testkit" % Versions.akka % "test",
     "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.akka % "test",
     "com.typesafe.akka" %% "akka-slf4j" % Versions.akka


### PR DESCRIPTION
## Incentive

see #90 
## Implementation

Created a MetricCollector actor to handle the metrics collection and reporting. See scalaDoc for detail. Refactored the AutoScaling to use this new MetricCollector's performance sample data and dramatically simplified the code (because it no longer needs to collect status from Queue, QueueProcess and Workers)
