### PR TITLE
Enable scoverage for multi-jvm tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ cache:
   - $HOME/.sbt/boot/
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean multi-jvm:test
-  - sbt ++$TRAVIS_SCALA_VERSION coverage test integration:test
+  - sbt ++$TRAVIS_SCALA_VERSION clean coverage test integration:test
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/build.sbt
+++ b/build.sbt
@@ -54,3 +54,4 @@ lazy val cluster = project
 
 addCommandAlias("validate", ";root;clean;compile;test;integration:test;multi-jvm:test")
 addCommandAlias("root", ";project root")
+

--- a/project/ClusterTests.scala
+++ b/project/ClusterTests.scala
@@ -7,24 +7,30 @@ object ClusterTests {
   val settings = Seq(
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-remote" % Versions.akka,
-      "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.akka
-    ),
+      "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.akka,
+      "org.scoverage" %% "scalac-scoverage-runtime" % "1.1.1"
+    ).map(_ % "test,multi-jvm"),
+
     compile in MultiJvm <<= (compile in MultiJvm) triggeredBy (compile in Test),
+
     // disable parallel tests
-    parallelExecution in Test := false
+    parallelExecution in Test := false,
+
     // make sure that MultiJvm tests are executed by the default test target,
     // and combine the results from ordinary test and multi-jvm tests
-//  temporarily disabled since scoverage doesn't support multi-jvm tests
-    //  executeTests in Test <<= (executeTests in Test, executeTests in MultiJvm) map {
-//      case (testResults, multiNodeResults)  =>
-//        val overall =
-//          if (testResults.overall.id < multiNodeResults.overall.id)
-//            multiNodeResults.overall
-//          else
-//            testResults.overall
-//        Tests.Output(overall,
-//          testResults.events ++ multiNodeResults.events,
-//          testResults.summaries ++ multiNodeResults.summaries)
-//    }
+    executeTests in Test <<= (executeTests in Test, executeTests in MultiJvm) map {
+      case (testResults, multiNodeResults) =>
+        val overall =
+          if (testResults.overall.id < multiNodeResults.overall.id)
+            multiNodeResults.overall
+          else
+            testResults.overall
+        Tests.Output(
+          overall,
+          testResults.events ++ multiNodeResults.events,
+          testResults.summaries ++ multiNodeResults.summaries
+        )
+    }
   )
 }
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,6 @@ object Dependencies {
   val akka = Seq(
     "com.typesafe.akka" %% "akka-actor" % Versions.akka,
     "com.typesafe.akka" %% "akka-testkit" % Versions.akka % "test",
-    "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.akka % "test",
     "com.typesafe.akka" %% "akka-slf4j" % Versions.akka
   )
 
@@ -18,6 +17,7 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-cluster" % Versions.akka,
     "com.typesafe.akka" %% "akka-cluster-tools" % Versions.akka
   )
+
   val (test, integration) = {
     val specs = Seq(
       "org.scalatest" %% "scalatest" % "2.2.6",


### PR DESCRIPTION
Including the `scalac-scoverage-runtime` dependency fixes the
`java.lang.NoClassDefFoundError: scoverage/Invoker$` error that occurs
when trying to run scoverage with multi-jvm tests.
