### PR TITLE
Improved whole system to  fix #113 and fix #114

### DIFF
--- a/cluster/src/main/scala/kanaloa/reactive/dispatcher/ClusterAwareBackend.scala
+++ b/cluster/src/main/scala/kanaloa/reactive/dispatcher/ClusterAwareBackend.scala
@@ -51,13 +51,13 @@ class ClusterAwareBackend(
 
 object ClusterAwareBackend {
   /**
-    *
-    * @param actorRefPath
-    * @param role
-    * @param system
-    * @param timeout for finding the actual remote actor ref
-    * @return
-    */
+   *
+   * @param actorRefPath
+   * @param role
+   * @param system
+   * @param timeout for finding the actual remote actor ref
+   * @return
+   */
   def apply(actorRefPath: String, role: String)(implicit system: ActorSystem, timeout: Timeout): ClusterAwareBackend = new ClusterAwareBackend(actorRefPath, role)
 
   private class RouteeRetriever(router: ActorRef, routingLogic: RoutingLogic)(implicit timeout: Timeout) extends Actor {

--- a/cluster/src/main/scala/kanaloa/reactive/dispatcher/ClusterAwareBackend.scala
+++ b/cluster/src/main/scala/kanaloa/reactive/dispatcher/ClusterAwareBackend.scala
@@ -52,12 +52,11 @@ class ClusterAwareBackend(
 
 object ClusterAwareBackend {
   /**
-   *
-   * @param actorRefPath
-   * @param role
-   * @param system
-   * @param timeout for finding the actual remote actor ref
-   * @return
+   * Creates a [[ClusterAwareBackend]]
+   * @param actorRefPath path of the remote actor
+   * @param role role of the node on which the remote actor is deployed
+   * @param system the cluster enabled [[ActorSystem]]
+   * @param timeout for finding the actual remote actor, which means both current node and remote node has to be in the cluster.
    */
   def apply(actorRefPath: String, role: String)(implicit system: ActorSystem, timeout: Timeout): ClusterAwareBackend = new ClusterAwareBackend(actorRefPath, role)
 

--- a/cluster/src/main/scala/kanaloa/reactive/dispatcher/ClusterAwareBackend.scala
+++ b/cluster/src/main/scala/kanaloa/reactive/dispatcher/ClusterAwareBackend.scala
@@ -27,7 +27,7 @@ class ClusterAwareBackend(
   maxNumberOfBackendNodes: Int          = 100
 )(implicit
   system: ActorSystem,
-  timeout: Timeout = 1.seconds) extends Backend {
+  timeout: Timeout) extends Backend {
 
   private[dispatcher] lazy val router: ActorRef = {
     val routerProps: Props = ClusterRouterGroup(
@@ -50,7 +50,15 @@ class ClusterAwareBackend(
 }
 
 object ClusterAwareBackend {
-  def apply(actorRefPath: String, role: String)(implicit system: ActorSystem): ClusterAwareBackend = new ClusterAwareBackend(actorRefPath, role)
+  /**
+    *
+    * @param actorRefPath
+    * @param role
+    * @param system
+    * @param timeout for finding the actual remote actor ref
+    * @return
+    */
+  def apply(actorRefPath: String, role: String)(implicit system: ActorSystem, timeout: Timeout): ClusterAwareBackend = new ClusterAwareBackend(actorRefPath, role)
 
   private class RouteeRetriever(router: ActorRef, routingLogic: RoutingLogic)(implicit timeout: Timeout) extends Actor {
     import context.dispatcher

--- a/cluster/src/main/scala/kanaloa/reactive/dispatcher/ClusterAwareBackend.scala
+++ b/cluster/src/main/scala/kanaloa/reactive/dispatcher/ClusterAwareBackend.scala
@@ -44,7 +44,8 @@ class ClusterAwareBackend(
   override def apply(f: ActorRefFactory): Future[ActorRef] = {
     val retriever = f.actorOf(ClusterAwareBackend.retrieverProps(router, routingLogic))
     import system.dispatcher
-    (retriever ? ClusterAwareBackend.GetRoutee).mapTo[RouteeRef].map(_.actorRef)
+    retriever.ask(ClusterAwareBackend.GetRoutee)(timeout = timeout.duration * 2).mapTo[RouteeRef].map(_.actorRef) //let the retriever handles the time internally.
+
   }
 
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -20,6 +20,9 @@ kanaloa {
 
       # Maximum number of workers
       maxPoolSize = 400
+
+      # check if worker pool is in a healthy state every such interval.
+      healthCheckInterval = 1s
     }
 
     circuitBreaker {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
@@ -188,7 +188,7 @@ object PullingDispatcher {
   )(resultChecker: ResultChecker)(implicit system: ActorSystem) = {
     val (settings, reporter) = Dispatcher.readConfig(name, rootConfig)
     //for pulling dispatchers because only a new idle worker triggers a pull of work, there maybe cases where there are two idle workers but the system should be deemed as fully utilized.
-    val metricsCollector = MetricsCollector(reporter, settings.performanceSamplerSettings.copy(fullyUtilized = _ <= 2))
+    val metricsCollector = MetricsCollector(reporter, settings.performanceSamplerSettings)
     val toBackend = implicitly[BackendAdaptor[T]]
     Props(PullingDispatcher(name, iterator, settings, toBackend(backend), metricsCollector, sendResultsTo, resultChecker)).withDeploy(Deploy.local)
   }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
@@ -25,7 +25,7 @@ trait Dispatcher extends Actor {
 
   protected def queueProps: Props
 
-  protected lazy val queue = context.actorOf(queueProps, name + "-backing-queue")
+  protected lazy val queue = context.actorOf(queueProps, "queue")
 
   private[dispatcher] val processor = {
     val props = QueueProcessor.default(
@@ -36,13 +36,13 @@ trait Dispatcher extends Actor {
       settings.circuitBreaker
     )(resultChecker)
 
-    context.actorOf(props, name + "-queue-processor")
+    context.actorOf(props, "queue-processor")
   }
 
   context watch processor
 
   private val autoScaler = settings.autoScaling.foreach { s ⇒
-    context.actorOf(AutoScaling.default(processor, s, metricsCollector), name + "-auto-scaler")
+    context.actorOf(AutoScaling.default(processor, s, metricsCollector), "auto-scaler")
   }
 
   def receive: Receive = ({
@@ -121,7 +121,7 @@ case class PushingDispatcher(
   protected lazy val queueProps = Queue.default(metricsCollector, WorkSettings(settings.workRetry, settings.workTimeout))
 
   settings.regulator.foreach { rs ⇒
-    context.actorOf(Regulator.props(rs, metricsCollector, self))
+    context.actorOf(Regulator.props(rs, metricsCollector, self), "regulator")
   }
 
   /**

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
@@ -133,15 +133,7 @@ private[dispatcher] trait PerformanceSampler extends Actor {
   private def tryComplete(status: QueueStatus): (Option[Report], QueueStatus) = {
     status.toSample(minSampleDuration) match {
       case sample @ Some(_) ⇒ (sample, status.copy(workDone = 0, start = Time.now))
-      case None ⇒
-        val report =
-          if (settings.reportNoProgress &&
-            status.duration > minSampleDuration &&
-            status.workDone == 0 &&
-            status.queueLength.value > 0)
-            Some(NoProgress(status.start, status.queueLength))
-          else None
-        (report, status)
+      case None             ⇒ (None, status)
     }
   }
 
@@ -166,8 +158,7 @@ private[dispatcher] object PerformanceSampler {
    */
   case class PerformanceSamplerSettings(
     sampleInterval:         FiniteDuration = 1.second,
-    minSampleDurationRatio: Double         = 0.3,
-    reportNoProgress:       Boolean        = true
+    minSampleDurationRatio: Double         = 0.3
   ) {
     val minSampleDuration: Duration = sampleInterval * minSampleDurationRatio
   }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
@@ -208,8 +208,4 @@ private[dispatcher] object PerformanceSampler {
    */
   case class PartialUtilization(numOfBusyWorkers: Int) extends Report
 
-  /**
-   * Indicate that system has been
-   */
-  case class NoProgress(since: Time, queueLength: QueueLength) extends Report
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
@@ -70,9 +70,9 @@ private[dispatcher] trait PerformanceSampler extends Actor {
     report(WorkQueueLength(queueLength.value))
 
   def fullyUtilized(s: QueueStatus): Receive = handleSubscriptions orElse {
-    case DispatchResult(idle, workLeft, full) ⇒
+    case DispatchResult(idle, workLeft, isFullyUtilized) ⇒
       reportQueueLength(workLeft)
-      if (!full) {
+      if (!isFullyUtilized) {
         val (rpt, _) = tryComplete(s)
         rpt foreach publish
         publishUtilization(idle, s.poolSize)
@@ -104,7 +104,7 @@ private[dispatcher] trait PerformanceSampler extends Actor {
   }
 
   def partialUtilized(poolSize: Int): Receive = handleSubscriptions orElse {
-    case DispatchResult(idle, workLeft, full) if full ⇒
+    case DispatchResult(idle, workLeft, isFullyUtilized) if isFullyUtilized ⇒
       context become fullyUtilized(
         QueueStatus(poolSize = poolSize, queueLength = workLeft)
       )

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Regulator.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Regulator.scala
@@ -66,7 +66,8 @@ class Regulator(settings: Settings, metricsCollector: ActorRef, regulatee: Actor
         status.copy(
           droppingRate = DroppingRate(0),
           burstDurationLeft = settings.durationOfBurstAllowed,
-          recordedAt = Time.now)
+          recordedAt = Time.now
+        )
       ) //reset to baseline when seeing a PartialUtilization
     case _: Report ⇒ //ignore other performance report
   }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Regulator.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Regulator.scala
@@ -1,7 +1,7 @@
 package kanaloa.reactive.dispatcher
 
 import akka.actor._
-import kanaloa.reactive.dispatcher.PerformanceSampler.{NoProgress, Report, PartialUtilization, Sample}
+import kanaloa.reactive.dispatcher.PerformanceSampler.{Report, PartialUtilization, Sample}
 import java.time.{LocalDateTime ⇒ Time}
 import kanaloa.reactive.dispatcher.Regulator.Status
 import kanaloa.reactive.dispatcher.metrics.Metric

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -137,18 +137,18 @@ class QueueOfIterator(
   val enqueuer = context.actorOf(enqueueerProps(iterator, sendResultsTo, self))
 
   /**
-    * Determines if a status indicates the workers pool are fully utilized.
-    * This is different from the default pushing [[DefaultQueue]]
-    * for a QueueOfIterator, it only gets work when there is at least one queued worker,
-    * which means there is a significant chance a second worker comes in before
-    * the first worker gets work. This number is still a bit arbitrary though.
-    * Obviously we still have to chose an arbitrary number as the threshold of queued workers
-    * with which we deem the queue as partially utilized.
-    * Todo: Right now we lack the insight of how to set this up correctly so I'd rather have
-    * it hard coded for now than allowing our users to tweak it without giving them any guidance
-    * @param status
-    * @return
-    */
+   * Determines if a status indicates the workers pool are fully utilized.
+   * This is different from the default pushing [[DefaultQueue]]
+   * for a QueueOfIterator, it only gets work when there is at least one queued worker,
+   * which means there is a significant chance a second worker comes in before
+   * the first worker gets work. This number is still a bit arbitrary though.
+   * Obviously we still have to chose an arbitrary number as the threshold of queued workers
+   * with which we deem the queue as partially utilized.
+   * Todo: Right now we lack the insight of how to set this up correctly so I'd rather have
+   * it hard coded for now than allowing our users to tweak it without giving them any guidance
+   * @param status
+   * @return
+   */
   def fullyUtilized(status: Status): Boolean = status.queuedWorkers.length <= 2
 
   override def onQueuedWorkExhausted(): Unit = enqueuer ! EnqueueMore

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -136,6 +136,19 @@ class QueueOfIterator(
 
   val enqueuer = context.actorOf(enqueueerProps(iterator, sendResultsTo, self))
 
+  /**
+    * Determines if a status indicates the workers pool are fully utilized.
+    * This is different from the default pushing [[DefaultQueue]]
+    * for a QueueOfIterator, it only gets work when there is at least one queued worker,
+    * which means there is a significant chance a second worker comes in before
+    * the first worker gets work. This number is still a bit arbitrary though.
+    * Obviously we still have to chose an arbitrary number as the threshold of queued workers
+    * with which we deem the queue as partially utilized.
+    * Todo: Right now we lack the insight of how to set this up correctly so I'd rather have
+    * it hard coded for now than allowing our users to tweak it without giving them any guidance
+    * @param status
+    * @return
+    */
   def fullyUtilized(status: Status): Boolean = status.queuedWorkers.length <= 2
 
   override def onQueuedWorkExhausted(): Unit = enqueuer ! EnqueueMore

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
@@ -63,7 +63,10 @@ class QueueProcessor(
       removeWorker(worker)
 
     case HealthCheck ⇒
-      tryCreateWorkersIfNeeded(settings.minPoolSize - currentWorkers)
+      if(currentWorkers < settings.minPoolSize) {
+        log.warning("Number of workers in pool is below minimum.")
+        tryCreateWorkersIfNeeded(settings.minPoolSize - currentWorkers)
+      }
 
     //if the Queue terminated, time to shut stuff down.
     case Terminated(`queue`) ⇒

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
@@ -63,7 +63,7 @@ class QueueProcessor(
       removeWorker(worker)
 
     case HealthCheck ⇒
-      if(currentWorkers < settings.minPoolSize) {
+      if (currentWorkers < settings.minPoolSize) {
         log.warning("Number of workers in pool is below minimum.")
         tryCreateWorkersIfNeeded(settings.minPoolSize - currentWorkers)
       }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
@@ -189,7 +189,7 @@ class Worker(
     def incrementTimeoutCount(): Unit = {
       timeoutCount = timeoutCount + 1
       if (timeoutCount >= settings.timeoutCountThreshold) {
-        delayBeforeNextWork = Some(settings.openDurationBase * timeoutCount)
+        delayBeforeNextWork = Some(settings.openDurationBase * timeoutCount.toLong)
         if (timeoutCount == settings.timeoutCountThreshold) //just crossed the threshold
           metricsCollector ! Metric.CircuitBreakerOpened
       }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -37,9 +37,10 @@ package kanaloa.reactive.dispatcher.queue {
    * @param minPoolSize
    */
   case class ProcessingWorkerPoolSettings(
-    startingPoolSize: Int = 5,
-    minPoolSize:      Int = 3,
-    maxPoolSize:      Int = 400
+    startingPoolSize:    Int            = 5,
+    minPoolSize:         Int            = 3,
+    maxPoolSize:         Int            = 400,
+    healthCheckInterval: FiniteDuration = 1.seconds
   )
 
   /**

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/Backends.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/Backends.scala
@@ -1,18 +1,14 @@
 package kanaloa.reactive.dispatcher
 
-import akka.actor.ActorRefFactory
+import akka.actor.{ActorRef, ActorRefFactory}
 import akka.testkit.{TestActors, TestProbe}
 import kanaloa.reactive.dispatcher.queue._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Promise, ExecutionContext, Future}
 
 trait Backends {
-  def delayedBackend(delayInMs: Long = 1000)(implicit ex: ExecutionContext) = new Backend {
-    def apply(f: ActorRefFactory): Future[QueueRef] = {
-      Future {
-        Thread.sleep(delayInMs)
-        f.actorOf(TestActors.echoActorProps)
-      }
-    }
+  def promiseBackend(promise: Promise[ActorRef])(implicit ex: ExecutionContext) = new Backend {
+    def apply(f: ActorRefFactory): Future[ActorRef] = promise.future
   }
+
 }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/Backends.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/Backends.scala
@@ -7,10 +7,10 @@ import kanaloa.reactive.dispatcher.queue._
 import scala.concurrent.{ExecutionContext, Future}
 
 trait Backends {
-  def delayedBackend(implicit ex: ExecutionContext) = new Backend {
+  def delayedBackend(delayInMs: Long = 1000)(implicit ex: ExecutionContext) = new Backend {
     def apply(f: ActorRefFactory): Future[QueueRef] = {
       Future {
-        Thread.sleep(1000)
+        Thread.sleep(delayInMs)
         f.actorOf(TestActors.echoActorProps)
       }
     }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
@@ -232,7 +232,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
             |  updateInterval = 50ms
             |  backPressure {
             |    durationOfBurstAllowed = 30ms
-            |    referenceDelay = 2s
+            |    referenceDelay = 1s
             |  }
             |}""".stripMargin
         )
@@ -240,7 +240,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
 
       //reach the point that it starts to reject work
       eventually {
-        (1 to 100).foreach(_ ⇒ dispatcher ! "a work")
+        (1 to 30).foreach(_ ⇒ dispatcher ! "a work")
         expectMsgType[WorkRejected](20.milliseconds)
       }(PatienceConfig(5.seconds, 40.milliseconds))
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
@@ -193,6 +193,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
       (received.length.toDouble / numOfWork.toDouble) shouldBe 0.5 +- 0.07
     }
 
+    //todo: move this to integration test once the integration re-org test PR is merged.
     "start to reject work when worker creation fails" in new ScopeWithActor with Eventually {
       val failingBackend = new Backend {
         def apply(f: ActorRefFactory): Future[ActorRef] = Future.failed(new Exception("failing backend"))
@@ -206,7 +207,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
             |  updateInterval = 10ms
             |  backPressure {
             |    durationOfBurstAllowed = 10ms
-            |    durationOfBurstAllowed = 0s
+            |    referenceDelay = 2s
             |  }
             |}""".stripMargin
         )
@@ -215,9 +216,10 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
       eventually {
         (1 to 100).foreach(_ ⇒ dispatcher ! "a work")
         expectMsgType[WorkRejected](20.milliseconds)
-      }(PatienceConfig(10.seconds, 200.milliseconds))
+      }(PatienceConfig(5.seconds, 40.milliseconds))
 
     }
+
   }
 
   "readConfig" should {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/PerformanceSamplerSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/PerformanceSamplerSpec.scala
@@ -16,13 +16,11 @@ class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with 
   val waitDuration = 30.milliseconds
 
   def initPerformanceSampler(
-    minSampleDurationRatio: Double  = 0,
-    reportNoProgress:       Boolean = false
+    minSampleDurationRatio: Double = 0
   )(implicit system: ActorSystem): (ActorRef, TestProbe) = {
     val ps = system.actorOf(MetricsCollector.props(None, PerformanceSamplerSettings(
       sampleInterval = waitDuration / 2,
-      minSampleDurationRatio = minSampleDurationRatio,
-      reportNoProgress
+      minSampleDurationRatio = minSampleDurationRatio
     )))
     ps ! fullyUtilizedResult //set it in the busy mode
     ps ! PoolSize(10)
@@ -69,11 +67,6 @@ class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with 
       subscriberProbe.expectNoMsg(waitDuration)
       ps ! WorkFailed
       subscriberProbe.expectMsgType[Sample].workDone should be(1)
-    }
-
-    "report NoProgress when no work done" in {
-      val (ps, subscriberProbe) = initPerformanceSampler(reportNoProgress = true)
-      subscriberProbe.expectMsgType[NoProgress].since.isBefore(Time.now) should be(true)
     }
 
     "resume to collect metrics once pool becomes busy again, but doesn't count old work" in {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/PerformanceSamplerSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/PerformanceSamplerSpec.scala
@@ -14,16 +14,18 @@ import scala.concurrent.duration._
 
 class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with Eventually {
   val waitDuration = 30.milliseconds
+  val startingPoolSize: Int = 10
 
   def initPerformanceSampler(
-    minSampleDurationRatio: Double = 0
+    minSampleDurationRatio: Double         = 0,
+    sampleInterval:         FiniteDuration = 30.seconds //relies on manual AddSample signal in tests
   )(implicit system: ActorSystem): (ActorRef, TestProbe) = {
     val ps = system.actorOf(MetricsCollector.props(None, PerformanceSamplerSettings(
-      sampleInterval = waitDuration / 2,
+      sampleInterval = sampleInterval,
       minSampleDurationRatio = minSampleDurationRatio
     )))
     ps ! fullyUtilizedResult //set it in the busy mode
-    ps ! PoolSize(10)
+    ps ! PoolSize(startingPoolSize)
     val subscriberProbe = TestProbe()
     ps ! Subscribe(subscriberProbe.ref)
     (ps, subscriberProbe)
@@ -33,46 +35,78 @@ class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with 
 
   "PerformanceSampler" should {
     "send Samples periodically" in {
-      val (ps, subscriberProbe) = initPerformanceSampler()
+      val (ps, subscriberProbe) = initPerformanceSampler(sampleInterval = 100.milliseconds)
       ps ! WorkCompleted(1.millisecond)
       ps ! WorkCompleted(1.millisecond)
 
       val sample1 = subscriberProbe.expectMsgType[Sample]
-      sample1.workDone should be(2)
+      sample1.workDone shouldBe 2
 
       ps ! WorkCompleted(1.millisecond)
 
       val sample2 = subscriberProbe.expectMsgType[Sample]
-      sample2.workDone should be(1)
+      sample2.workDone shouldBe 1
 
-      sample2.start.isAfter(sample1.start) should be(true)
+      sample2.start.isAfter(sample1.start) shouldBe true
 
     }
 
     "ignore metrics when pool isn't fully occupied" in {
       val (ps, subscriberProbe) = initPerformanceSampler()
       ps ! partialUtilizedResult
-      subscriberProbe.expectMsgType[PartialUtilization].numOfBusyWorkers should be(9)
+
+      subscriberProbe.expectMsgType[Sample] //last sample when fully utilized
+      subscriberProbe.expectMsgType[PartialUtilization].numOfBusyWorkers shouldBe 9
 
       ps ! WorkCompleted(1.millisecond)
       ps ! WorkCompleted(1.millisecond)
-
+      ps ! AddSample
       subscriberProbe.expectNoMsg(waitDuration)
+
+    }
+
+    "sends sample without work" in {
+      val (ps, subscriberProbe) = initPerformanceSampler()
+
+      ps ! AddSample
+
+      subscriberProbe.expectMsgType[Sample].workDone shouldBe 0
+
+    }
+
+    "continually sends sample without work without reseting start" in {
+      val (ps, subscriberProbe) = initPerformanceSampler()
+
+      ps ! AddSample
+
+      val sample1 = subscriberProbe.expectMsgType[Sample]
+
+      Thread.sleep(30) //add a distance between first and second sample
+      ps ! DispatchResult(0, QueueLength(4), true)
+      ps ! AddSample
+      val sample2 = subscriberProbe.expectMsgType[Sample]
+      sample2.end.isAfter(sample1.end) shouldBe true
+      sample1.start shouldBe sample2.start
+      sample2.queueLength shouldBe QueueLength(4)
 
     }
 
     "ignore Work timeout but include failed Work " in {
       val (ps, subscriberProbe) = initPerformanceSampler()
       ps ! WorkTimedOut
-      subscriberProbe.expectNoMsg(waitDuration)
+      ps ! AddSample
+      subscriberProbe.expectMsgType[Sample].workDone shouldBe 0
+
       ps ! WorkFailed
-      subscriberProbe.expectMsgType[Sample].workDone should be(1)
+      ps ! AddSample
+
+      subscriberProbe.expectMsgType[Sample].workDone shouldBe 1
     }
 
     "resume to collect metrics once pool becomes busy again, but doesn't count old work" in {
       val (ps, subscriberProbe) = initPerformanceSampler()
       ps ! partialUtilizedResult
-
+      subscriberProbe.expectMsgType[Sample] //last sample when fully utilized
       subscriberProbe.expectMsgType[PartialUtilization]
 
       ps ! WorkCompleted(1.millisecond)
@@ -82,7 +116,8 @@ class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with 
 
       ps ! WorkCompleted(1.millisecond)
 
-      subscriberProbe.expectMsgType[Sample].workDone should be(1)
+      ps ! AddSample
+      subscriberProbe.expectMsgType[Sample].workDone shouldBe 1
 
     }
 
@@ -92,14 +127,20 @@ class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with 
       ps ! WorkCompleted(1.millisecond)
       ps ! WorkCompleted(1.millisecond)
 
-      subscriberProbe.expectMsgType[Sample].workDone should be(2)
+      ps ! AddSample
+
+      subscriberProbe.expectMsgType[Sample].workDone shouldBe 2
 
       ps ! PoolSize(12)
+      subscriberProbe.expectMsgType[Sample].workDone shouldBe 0
+
       ps ! WorkCompleted(1.millisecond)
 
+      ps ! AddSample
+
       val sample = subscriberProbe.expectMsgType[Sample]
-      sample.workDone should be(1)
-      sample.poolSize should be(12)
+      sample.workDone shouldBe 1
+      sample.poolSize shouldBe 12
 
     }
 
@@ -107,26 +148,29 @@ class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with 
       val (ps, subscriberProbe) = initPerformanceSampler()
 
       ps ! DispatchResult(0, QueueLength(11), true)
-      ps ! WorkCompleted(1.millisecond)
+      ps ! AddSample
 
-      subscriberProbe.expectMsgType[Sample].queueLength.value should be(11)
-
+      subscriberProbe.expectMsgType[Sample].queueLength.value shouldBe 11
       ps ! PoolSize(12)
-      ps ! WorkCompleted(1.millisecond)
+      subscriberProbe.expectMsgType[Sample]
 
-      subscriberProbe.expectMsgType[Sample].queueLength.value should be(11)
+      ps ! AddSample
+
+      subscriberProbe.expectMsgType[Sample].queueLength.value shouldBe 11
     }
 
     "register pool size when resting" in {
       val (ps, subscriberProbe) = initPerformanceSampler()
 
       ps ! partialUtilizedResult
+      subscriberProbe.expectMsgType[Sample]
       subscriberProbe.expectMsgType[PartialUtilization]
 
       ps ! PoolSize(15)
       ps ! fullyUtilizedResult
       ps ! WorkCompleted(1.millisecond)
-      subscriberProbe.expectMsgType[Sample].poolSize should be(15)
+      ps ! AddSample
+      subscriberProbe.expectMsgType[Sample].poolSize shouldBe 15
 
     }
 
@@ -135,29 +179,33 @@ class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with 
 
       ps ! DispatchResult(0, QueueLength(21), true)
       ps ! WorkCompleted(1.millisecond)
+      ps ! AddSample
 
       subscriberProbe.expectMsgType[Sample].queueLength shouldBe QueueLength(21)
 
     }
 
     "continue counting when sample duration not long enough" in {
-      val (ps, subscriberProbe) = initPerformanceSampler(0.99)
+      val (ps, subscriberProbe) = initPerformanceSampler(0.99, waitDuration)
       ps ! WorkCompleted(1.millisecond)
       ps ! AddSample
-      subscriberProbe.expectNoMsg(waitDuration / 5)
+      subscriberProbe.expectNoMsg(waitDuration / 3)
+
       ps ! WorkCompleted(1.millisecond)
-      subscriberProbe.expectMsgType[Sample].workDone should be(2)
+
+      subscriberProbe.expectMsgType[Sample].workDone shouldBe 2
     }
 
     "reset counting when pool size changed" in {
-      val (ps, subscriberProbe) = initPerformanceSampler(0.99)
+      val (ps, subscriberProbe) = initPerformanceSampler()
       ps ! WorkCompleted(1.millisecond)
       ps ! PoolSize(15)
-      subscriberProbe.expectNoMsg(waitDuration / 5)
+      subscriberProbe.expectMsgType[Sample].poolSize shouldBe startingPoolSize
       ps ! WorkCompleted(1.millisecond)
+      ps ! AddSample
       val sample = subscriberProbe.expectMsgType[Sample]
-      sample.workDone should be(1)
-      sample.poolSize should be(15)
+      sample.workDone shouldBe 1
+      sample.poolSize shouldBe 15
     }
 
     "forward metrics to metric reporter" in {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
@@ -63,17 +63,6 @@ class RegulatorSpec extends SpecWithActorSystem {
       regulatee.expectMsgType[DroppingRate].value should be > 0d //send dropping rate when burst allowed used up.
     }
 
-    "send dropRate when no progress were made" in {
-      val regulatee = TestProbe()
-      val regulator = system.actorOf(Regulator.props(settings(), TestProbe().ref, regulatee.ref))
-
-      regulator ! NoProgress(2.seconds.ago, QueueLength(20)) //starts the regulator
-
-      regulator ! NoProgress(2.seconds.ago, QueueLength(40)) //starts the regulator
-
-      regulatee.expectMsgType[DroppingRate].value should be > 0d //send dropping rate when burst allowed used up.
-    }
-
     "update recordedAt" in {
       val lastStatus = status(averageSpeed = 0.2, recordedAt = 2000.milliseconds.ago)
       val result = update(sample(), lastStatus, settings())

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
@@ -1,7 +1,7 @@
 package kanaloa.reactive.dispatcher
 
 import akka.testkit.TestProbe
-import kanaloa.reactive.dispatcher.PerformanceSampler.{PartialUtilization, NoProgress, Subscribe, Sample}
+import kanaloa.reactive.dispatcher.PerformanceSampler.{PartialUtilization, Subscribe, Sample}
 import kanaloa.reactive.dispatcher.Regulator.{DroppingRate, Status, Settings}
 import kanaloa.reactive.dispatcher.Types.{Speed, QueueLength}
 import kanaloa.reactive.dispatcher.metrics.Metric

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
@@ -1,7 +1,7 @@
 package kanaloa.reactive.dispatcher
 
 import akka.testkit.TestProbe
-import kanaloa.reactive.dispatcher.PerformanceSampler.{NoProgress, Subscribe, Sample}
+import kanaloa.reactive.dispatcher.PerformanceSampler.{PartialUtilization, NoProgress, Subscribe, Sample}
 import kanaloa.reactive.dispatcher.Regulator.{DroppingRate, Status, Settings}
 import kanaloa.reactive.dispatcher.Types.{Speed, QueueLength}
 import kanaloa.reactive.dispatcher.metrics.Metric
@@ -63,6 +63,19 @@ class RegulatorSpec extends SpecWithActorSystem {
       regulatee.expectMsgType[DroppingRate].value should be > 0d //send dropping rate when burst allowed used up.
     }
 
+    "reset drop rate after seeing a PartialUtilization" in {
+      val regulatee = TestProbe()
+      val regulator = system.actorOf(Regulator.props(settings(), TestProbe().ref, regulatee.ref))
+      regulator ! sample() //starts the regulator
+
+      regulator ! sample(workDone = 1, queueLength = 10000)
+      regulatee.expectMsgType[DroppingRate].value shouldBe 1d //does not send dropping rate larger than zero when within a burst
+
+      regulator ! PartialUtilization(3)
+      regulatee.expectMsgType[DroppingRate].value shouldBe 0d //does not send dropping rate larger than zero when within a burst
+
+    }
+
     "update recordedAt" in {
       val lastStatus = status(averageSpeed = 0.2, recordedAt = 2000.milliseconds.ago)
       val result = update(sample(), lastStatus, settings())
@@ -85,6 +98,17 @@ class RegulatorSpec extends SpecWithActorSystem {
       ).delay
 
       delay.toMillis shouldBe 1000
+    }
+
+    "calculates status from zero speed sample" in {
+      val newStatus = update(
+        sample(workDone = 0, duration = 1.second, queueLength = 175), //speed of 0.1
+        status(averageSpeed = 0),
+        settings()
+      )
+
+      newStatus.averageSpeed.value shouldBe 0
+      newStatus.delay shouldBe 175.seconds
     }
 
     "update p using based factors when p > 10%" in {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
@@ -189,7 +189,7 @@ class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backen
       val queueProcessor = system.actorOf(
         QueueProcessor.default(
           queueProbe.ref,
-          delayedBackend,
+          delayedBackend(),
           ProcessingWorkerPoolSettings(),
           TestProbe().ref
         )(ResultChecker.complacent)

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
@@ -12,12 +12,13 @@ import kanaloa.reactive.dispatcher.queue.QueueProcessor.{ScaleTo, Shutdown, Shut
 import kanaloa.reactive.dispatcher._
 import kanaloa.reactive.dispatcher.queue.TestUtils.{MessageProcessed, DelegateeMessage}
 import org.scalatest.concurrent.Eventually
-
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
 import scala.collection.mutable.{Map ⇒ MMap}
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backends {
+class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backends with MockitoSugar {
 
   type QueueTest = (TestActorRef[QueueProcessor], TestProbe, TestProbe, TestBackend, TestWorkerFactory) ⇒ Any
 
@@ -107,13 +108,37 @@ class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backen
         }
       }
 
-    "attempt to keep the number of Workers at the minimumWorkers" in withQueueProcessor() { (qp, queueProbe, metricsCollector, testBackend, workerFactory) ⇒
-      //current workers are 5, minimum workers are 3, so killing 4 should result in 2 new recreate attempts
-      workerFactory.probeMap.keys.take(4).foreach(workerFactory.killAndRemoveWorker)
+    "attempt to keep the number of Workers at the minimumWorkers when worker dies" in withQueueProcessor(ProcessingWorkerPoolSettings(healthCheckInterval = 10.milliseconds)) {
+      (qp, queueProbe, metricsCollector, testBackend, workerFactory) ⇒
+        //current workers are 5, minimum workers are 3, so killing 4 should result in 2 new recreate attempts
+        workerFactory.probeMap.keys.take(4).foreach(workerFactory.killAndRemoveWorker)
+        eventually {
+          qp.underlyingActor.workerPool should have size 3
+          testBackend.timesInvoked shouldBe 7 //2 new invocations should have happened
+          workerFactory.probeMap should have size 3 //should only be 3 workers
+        }
+    }
+
+    "attempt to retry create Workers until it hits the minimumWorkers" in {
+      val settings = ProcessingWorkerPoolSettings(minPoolSize = 2, startingPoolSize = 2, healthCheckInterval = 10.milliseconds)
+
+      val testBackend = new Backend {
+        var count = 0
+        def apply(af: ActorRefFactory) = {
+          if (count > 2) Future.successful(TestProbe().ref)
+          else {
+            count += 1
+            Future.failed(new Exception("failed"))
+          }
+        }
+      }
+      val qp = TestActorRef[QueueProcessor](QueueProcessor.default(
+        TestProbe("queue").ref,
+        testBackend, settings, TestProbe("metrics-collector").ref
+      )(SimpleResultChecker))
+
       eventually {
-        qp.underlyingActor.workerPool should have size 3
-        testBackend.timesInvoked shouldBe 7 //2 new invocations should have happened
-        workerFactory.probeMap should have size 3 //should only be 3 workers
+        qp.underlyingActor.workerPool should have size 2
       }
     }
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.concurrent.Eventually
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import scala.collection.mutable.{Map ⇒ MMap}
-import scala.concurrent.Future
+import scala.concurrent.{Promise, Future}
 import scala.concurrent.duration._
 
 class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backends with MockitoSugar {
@@ -189,7 +189,7 @@ class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backen
       val queueProcessor = system.actorOf(
         QueueProcessor.default(
           queueProbe.ref,
-          delayedBackend(),
+          promiseBackend(Promise[ActorRef]),
           ProcessingWorkerPoolSettings(),
           TestProbe().ref
         )(ResultChecker.complacent)


### PR DESCRIPTION
The solution 
1. implemented a health check on QueueProcessor so that it constantly tries to make sure there are at least minimum number of workers in the pool 
2. Improved the traffic regulator to deal with the situation when no work is done at all, so that if such situation happens the dispatcher will start to reject work. 

Note that this didn't implement a Future based API, I feel that would be most appropriate in `ClusterAwareBackend` factory, which it could return a Future of `Backend` that completes only when the routes are read, a ticket is created for that #116
