### PR TITLE
adding intermediate WorkSending Actor to send messages to Routees

### DIFF
--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
@@ -177,10 +177,11 @@ private[queue] class Worker(
 
   private def sendWorkToRoutee(work: Work, retried: Int): Unit = {
     workCounter += 1 //do we increase this on a retry?
-    val sender = context.actorOf(WorkSender.props(self, routee, RelayWork(workCounter, work.messageToDelegatee, delayBeforeNextWork)))
+    val newWorkId = workCounter
+    val sender = context.actorOf(WorkSender.props(self, routee, RelayWork(newWorkId, work.messageToDelegatee, delayBeforeNextWork)))
     context.watch(sender)
     val timeout = delayedMsg(delayBeforeNextWork.getOrElse(Duration.Zero) + work.settings.timeout, RouteeTimeout)
-    val out = Outstanding(work, workCounter, timeout, sender, retried)
+    val out = Outstanding(work, newWorkId, timeout, sender, retried)
     context become working(out)
   }
 

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Worker.scala
@@ -289,7 +289,6 @@ private[queue] class WorkSender(worker: ActorRef, routee: ActorRef, relayWork: R
   maybeDelayedMsg(delay, message, routee)
 
   def receive: Receive = {
-
     case x ⇒ worker ! WorkResult(workId, x)
   }
 }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/WorkerRetiringSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/WorkerRetiringSpec.scala
@@ -61,7 +61,7 @@ class WorkerUnregisteringBusySpec extends WorkerSpec {
     }
 
     "transition to 'unregisteringIdle' if WorkComplete" in withUnregisteringBusyWorker { (worker, queueProbe, routeeProbe, work) ⇒
-      routeeProbe.send(worker, Result("finished!"))
+      routeeProbe.reply(Result("finished!"))
       expectMsg("finished!")
       assertWorkerStatus(worker, Worker.UnregisteringIdle)
     }
@@ -73,7 +73,7 @@ class WorkerUnregisteringBusySpec extends WorkerSpec {
     }
 
     "transition to 'unregisteringIdle' if Work fails" in withUnregisteringBusyWorker { (worker, queueProbe, routeeProbe, work) ⇒
-      routeeProbe.send(worker, Fail("finished!"))
+      routeeProbe.reply(Fail("finished!"))
       expectMsgType[WorkFailed]
       assertWorkerStatus(worker, Worker.UnregisteringIdle)
     }
@@ -117,13 +117,13 @@ class WorkerWaitingToTerminateSpec extends WorkerSpec {
     }
 
     "terminate when the Work completes" in withTerminatingWorker() { (worker, queueProbe, routeeProbe, work) ⇒
-      routeeProbe.send(worker, Result("finished!"))
+      routeeProbe.reply(Result("finished!"))
       expectMsg("finished!")
       expectTerminated(worker)
     }
 
     "terminate if the Work fails" in withTerminatingWorker() { (worker, queueProbe, routeeProbe, work) ⇒
-      routeeProbe.send(worker, Fail("fail"))
+      routeeProbe.reply(Fail("fail"))
       expectMsgType[WorkFailed]
       expectTerminated(worker)
     }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/WorkerWorkingSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/WorkerWorkingSpec.scala
@@ -117,6 +117,7 @@ class WorkerWorkingSpec extends WorkerSpec {
       routeeB.reply(Result("B Result!"))
 
       expectMsg("B Result!")
+      expectNoMsg(30.milliseconds)
     }
   }
 


### PR DESCRIPTION
## What

There were some assumptions in `Worker` that the `Routee` that it was communicating with, would always be the same Actor who responded to it.  In certain cases, ie: If the `Routee` is itself an akka Router, the actual Actor who responds back to the `Worker` is not the `Routee`, but some proxied Actor.  This causes failures in `Worker`, since it assumes that only messages which originate from the actual `Routee` are the response.  The effect is that the `Worker` ends up timing out all requests since in its eyes, it never received a response from the `Routee`.

Another issue which cropped up during this is that we discovered a bug where the potential to criss cross responses to Work is real a thing.  The scenario goes something like:
- Worker receives Work1, sends it to Routee
- Worker times out Work1
- Worker receives Work2, sends it to Routee
- Worker receives the response for Work1
- Worker passes it along.
## Fix

To fix both of these issues, the `Worker` now will, for every `Work` it receives, spawn an intermediate Actor, `WorkSender`.  This `WorkSender` is responsible for sending the message to the `Routee` and then waiting for its response(ie: the ask pattern).  It then forwards that response back to the `Worker`. That ensures that the message the `WorkSender` receives is always from the `Routee`(or proxied Actor) and for the current `Work` it was assigned.  The `WorkSender` is only alive for the duration of the request, and is shut down after it times out, fails,  or returns a response.

As added protection, the Worker now assigns a unique id to each piece of `Work` it receives, and `WorkSender` will tack this id on to the `WorkResult`.  Upon receiving a `WorkResult`, the `Worker` first checks to make sure the ids match, and discards any message that doesn't match.
