### PR TITLE
Fix #118 renamed autoScaler to autothrottle

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -85,7 +85,7 @@ kanaloa {
     # Elasticsearch cluster may handle 4-8 concurrent requests at optimal speed.
     # The dispatchers keep track of throughput at each pool size and perform the following
     # three resizing operations (one at a time) periodically:
-    #   1. Downsize if it hasn't seen all workers ever fully utilized for a period of time.
+    # 1. Downsize if it hasn't seen all workers ever fully utilized for a period of time.
     # 2. Explore to a random nearby pool size to try and collect throughput metrics.
     # 3. Optimize to a nearby pool size with a better (than any other nearby sizes)
     #    throughput metrics.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -75,7 +75,29 @@ kanaloa {
       weightOfLatestMetric = 0.3
     }
 
-    autoScaling {
+    # It automatically adjust the size of work pool (and thus the concurrency)
+    # to an optimal one that provides the highest throughput.
+    # This autothrottle works best when you expect the concurrency to performance function
+    # to be a convex function, with which you can find a global optimal by walking towards
+    # a better concurrency. For example, a CPU bound service may have an optimal concurrency
+    # tied to the CPU cores available. When your service is IO bound, the optimal concurrency is
+    # bound to optimal number of concurrent connections to that IO service - e.g. a 4 node
+    # Elasticsearch cluster may handle 4-8 concurrent requests at optimal speed.
+    # The dispatchers keep track of throughput at each pool size and perform the following
+    # three resizing operations (one at a time) periodically:
+    #   1. Downsize if it hasn't seen all workers ever fully utilized for a period of time.
+    # 2. Explore to a random nearby pool size to try and collect throughput metrics.
+    # 3. Optimize to a nearby pool size with a better (than any other nearby sizes)
+    #    throughput metrics.
+    # When the pool is fully-utilized (i.e. all workers are busy), it randomly chooses
+    # between exploring and optimizing. When the pool has not been fully-utilized for a period of
+    # time, it will downsize the pool to the last seen max utilization multiplied by
+    # a configurable ratio.
+    #
+    # By constantly exploring and optimizing, the resizer will eventually walk to the optimal
+    # size and remain nearby.
+    # When the optimal size changes it will start walking towards the new one.
+    autothrottle {
 
       enabled = on
 
@@ -83,14 +105,14 @@ kanaloa {
       # during exploration.
       chanceOfScalingDownWhenFull = 0.1
 
-      # Interval between each scaling attempt
-      scalingInterval = ${kanaloa.default-dispatcher.updateInterval}
+      # Interval between each pool size adjustment attempt
+      resizeInterval = ${kanaloa.default-dispatcher.updateInterval}
 
       # If the workers have not been fully utilized (i.e. all workers are busy) for such length,
-      # the autoScaling will downsize the pool.
+      # the autothrottle will downsize the pool.
       downsizeAfterUnderUtilization = 72h
 
-      # When optimizing, the autoScaler only considers the sizes adjacent to the
+      # When optimizing, the autothrottler only considers the sizes adjacent to the
       # current size. This number indicates how many adjacent sizes to consider.
       numOfAdjacentSizesToConsiderDuringOptimization = 12
 
@@ -100,7 +122,7 @@ kanaloa {
       # exploration will be +- 5
       exploreStepSize = 0.1
 
-      # When downsizing after a long streak of underutilization, the autoScaler
+      # When downsizing after a long streak of underutilization, the autothrottler
       # will downsize the pool to the highest utiliziation multiplied by a
       # a downsize ratio. This downsize ratio determines the new pool size
       # in comparison to the highest utilization.
@@ -119,10 +141,6 @@ kanaloa {
       # representing pool size 5 will be 6 * 0.3 + 10 * 0.7, i.e. 8.8 millis
       # Obviously, this number should be between 0 and 1.
       weightOfLatestMetric = 0.5
-
-      # The autoscaler collects information from other actors to gather metrics.
-      # This is the time out for this collection
-      statusCollectionTimeout = 3s
     }
 
     # Metrics report configuration

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
@@ -41,8 +41,8 @@ trait Dispatcher extends Actor {
 
   context watch processor
 
-  private val autoScaler = settings.autoScaling.foreach { s ⇒
-    context.actorOf(AutoScaling.default(processor, s, metricsCollector), "auto-scaler")
+  private val autothrottler = settings.autothrottle.foreach { s ⇒
+    context.actorOf(Autothrottler.default(processor, s, metricsCollector), "auto-scaler")
   }
 
   def receive: Receive = ({
@@ -62,7 +62,7 @@ object Dispatcher {
     workerPool:     ProcessingWorkerPoolSettings,
     regulator:      Option[Regulator.Settings],
     circuitBreaker: Option[CircuitBreakerSettings],
-    autoScaling:    Option[AutoScalingSettings]
+    autothrottle:    Option[AutothrottleSettings]
   ) {
     val performanceSamplerSettings = PerformanceSampler.PerformanceSamplerSettings(updateInterval)
   }
@@ -86,7 +86,7 @@ object Dispatcher {
     settings.copy(
       regulator = readComponent[Regulator.Settings]("backPressure", config),
       circuitBreaker = readComponent[CircuitBreakerSettings]("circuitBreaker", config),
-      autoScaling = readComponent[AutoScalingSettings]("autoScaling", config)
+      autothrottle = readComponent[AutothrottleSettings]("autothrottle", config)
     )
   }
 

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
@@ -62,7 +62,7 @@ object Dispatcher {
     workerPool:     ProcessingWorkerPoolSettings,
     regulator:      Option[Regulator.Settings],
     circuitBreaker: Option[CircuitBreakerSettings],
-    autothrottle:    Option[AutothrottleSettings]
+    autothrottle:   Option[AutothrottleSettings]
   ) {
     val performanceSamplerSettings = PerformanceSampler.PerformanceSamplerSettings(updateInterval)
   }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
@@ -6,7 +6,7 @@ import akka.actor._
 import kanaloa.reactive.dispatcher.ApiProtocol.QueryStatus
 import kanaloa.reactive.dispatcher.PerformanceSampler
 import kanaloa.reactive.dispatcher.PerformanceSampler._
-import kanaloa.reactive.dispatcher.queue.AutoScaling._
+import kanaloa.reactive.dispatcher.queue.Autothrottler._
 import kanaloa.reactive.dispatcher.queue.QueueProcessor.ScaleTo
 import kanaloa.util.Java8TimeExtensions._
 import kanaloa.util.MessageScheduler
@@ -16,33 +16,13 @@ import scala.language.implicitConversions
 import scala.util.Random
 
 /**
- *  Auto-scales the work pool to an optimal size that provides the highest throughput.
- *  This auto-scaling works best when you expect the pool size to performance function
- *  to be a convex function, with which you can find a global optimal by walking towards
- *  a better size. For example, a CPU bound service may have an optimal worker pool size
- *  tied to the CPU cores available. When your service is IO bound, the optimal size is
- *  bound to optimal number of concurrent connections to that IO service - e.g. a 4 node
- *  Elasticsearch cluster may handle 4-8 concurrent requests at optimal speed.
- *  The dispatchers keep track of throughput at each pool size and perform the following
- *  three resizing operations (one at a time) periodically:
- *  1. Downsize if it hasn't seen all workers ever fully utilized for a period of time.
- *  2. Explore to a random nearby pool size to try and collect throughput metrics.
- *  3. Optimize to a nearby pool size with a better (than any other nearby sizes)
- *     throughput metrics.
- *  When the pool is fully-utilized (i.e. all workers are busy), it randomly chooses
- *  between exploring and optimizing. When the pool has not been fully-utilized for a period of
- *  time, it will downsize the pool to the last seen max utilization multiplied by
- *  a configurable ratio.
- *
- *  By constantly exploring and optimizing, the resizer will eventually walk to the optimal
- *  size and remain nearby.
- *  When the optimal size changes it will start walking towards the new one.
+ * For mechanisms see docs in the autothrottle section in reference.conf
  */
-trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
+trait Autothrottler extends Actor with ActorLogging with MessageScheduler {
   val processor: QueueProcessorRef
   val metricsCollector: ActorRef
 
-  val settings: AutoScalingSettings
+  val settings: AutothrottleSettings
 
   import settings._
 
@@ -55,7 +35,7 @@ trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
     metricsCollector ! Subscribe(self)
     context watch processor
     import context.dispatcher
-    actionScheduler = Some(context.system.scheduler.schedule(scalingInterval, scalingInterval, self, OptimizeOrExplore))
+    actionScheduler = Some(context.system.scheduler.schedule(resizeInterval, resizeInterval, self, OptimizeOrExplore))
   }
 
   override def postStop(): Unit = {
@@ -91,7 +71,7 @@ trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
       if (start.isBefore(Time.now.minus(downsizeAfterUnderUtilization)))
         processor ! ScaleTo((highestUtilization * downsizeRatio).toInt, Some("downsizing"))
     case qs: QueryStatus ⇒
-      qs.reply(AutoScalingStatus(partialUtilization = Some(highestUtilization), partialUtilizationStart = Some(start)))
+      qs.reply(AutothrottleStatus(partialUtilization = Some(highestUtilization), partialUtilizationStart = Some(start)))
 
     case _: PerformanceSampler.Report ⇒ //ignore other performance report
   }
@@ -117,7 +97,7 @@ trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
       processor ! action
 
     case qs: QueryStatus ⇒
-      qs.reply(AutoScalingStatus(poolSize = Some(currentSize), performanceLog = perfLog))
+      qs.reply(AutothrottleStatus(poolSize = Some(currentSize), performanceLog = perfLog))
 
     case _: PerformanceSampler.Report ⇒ //ignore other performance report
   }
@@ -149,13 +129,13 @@ trait AutoScaling extends Actor with ActorLogging with MessageScheduler {
   private implicit def durationToJDuration(d: FiniteDuration): JDuration = JDuration.ofNanos(d.toNanos)
 }
 
-object AutoScaling {
+object Autothrottler {
   case object OptimizeOrExplore
 
   /**
    * Mostly for testing purpose
    */
-  private[queue] case class AutoScalingStatus(
+  private[queue] case class AutothrottleStatus(
     partialUtilization:      Option[Int]      = None,
     partialUtilizationStart: Option[Time]     = None,
     performanceLog:          PerformanceLog   = Map.empty,
@@ -168,13 +148,13 @@ object AutoScaling {
 
   case class Default(
     processor:        QueueProcessorRef,
-    settings:         AutoScalingSettings,
+    settings:         AutothrottleSettings,
     metricsCollector: ActorRef
-  ) extends AutoScaling
+  ) extends Autothrottler
 
   def default(
     processor:        QueueProcessorRef,
-    settings:         AutoScalingSettings,
+    settings:         AutothrottleSettings,
     metricsCollector: ActorRef
   ) = Props(Default(processor, settings, metricsCollector)).withDeploy(Deploy.local)
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -46,25 +46,23 @@ package kanaloa.reactive.dispatcher.queue {
 
   /**
    *
-   * @param chanceOfScalingDownWhenFull chance of scaling down when the worker pool is fully utlized
-   * @param scalingInterval  duration between each scaling attempt
+   * @param chanceOfScalingDownWhenFull chance of scaling down when the worker pool is fully utilized
+   * @param resizeInterval  duration between each pool size adjustment attempt
    * @param downsizeAfterUnderUtilization start to downsize after underutilized for period, should be long enough to include at least one traffic cycle.
    * @param numOfAdjacentSizesToConsiderDuringOptimization during optimization, it only looks at this number of adjacent pool sizes (adjacent to current pool size), to figure out the optimal pool size to move to
    * @param exploreStepSize during exploration, it takes as big a step as this size. It's a ratio to the current pool size, so if the current size is 10 and the exploreStepSize is 0.2, the exploration will be within a range between 8 and 12
    * @param downsizeRatio during downsizing, it will downsize to the largest number of concurrently occupied workers it has seen plus a buffer zone, this downsizeRatio determines the buffer size.
    * @param explorationRatio chance of doing a exploration vs an optimization
-   * @param statusCollectionTimeout maximum time allowed when autoscaler collects status from queue, queueProcessor and all workers
    */
-  case class AutoScalingSettings(
+  case class AutothrottleSettings(
     chanceOfScalingDownWhenFull:                    Double         = 0.1,
-    scalingInterval:                                FiniteDuration = 5.seconds,
+    resizeInterval:                                FiniteDuration = 5.seconds,
     downsizeAfterUnderUtilization:                  FiniteDuration = 72.hours,
     numOfAdjacentSizesToConsiderDuringOptimization: Int            = 12,
     exploreStepSize:                                Double         = 0.1,
     downsizeRatio:                                  Double         = 0.8,
     explorationRatio:                               Double         = 0.4,
-    weightOfLatestMetric:                           Double         = 0.5,
-    statusCollectionTimeout:                        FiniteDuration = 30.seconds
+    weightOfLatestMetric:                           Double         = 0.5
   )
 
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -56,7 +56,7 @@ package kanaloa.reactive.dispatcher.queue {
    */
   case class AutothrottleSettings(
     chanceOfScalingDownWhenFull:                    Double         = 0.1,
-    resizeInterval:                                FiniteDuration = 5.seconds,
+    resizeInterval:                                 FiniteDuration = 5.seconds,
     downsizeAfterUnderUtilization:                  FiniteDuration = 72.hours,
     numOfAdjacentSizesToConsiderDuringOptimization: Int            = 12,
     exploreStepSize:                                Double         = 0.1,

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
@@ -21,7 +21,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
       val pwp = system.actorOf(Props(PullingDispatcher(
         "test",
         iterator,
-        Dispatcher.defaultDispatcherSettings().copy(workerPool = ProcessingWorkerPoolSettings(1), autoScaling = None),
+        Dispatcher.defaultDispatcherSettings().copy(workerPool = ProcessingWorkerPoolSettings(1), autothrottle = None),
         backend,
         metricsCollector = MetricsCollector(None),
         None,
@@ -175,7 +175,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
             |kanaloa.default-dispatcher {
             |  updateInterval = 300s
             |  circuitBreaker.enabled = off
-            |  autoScaling.enabled = off
+            |  autothrottle.enabled = off
             |}""".stripMargin
         ) //make sure regulator doesn't interfere
       )(ResultChecker.complacent))
@@ -258,7 +258,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
     "use default settings when nothing is in config" in {
       val (settings, reporter) = Dispatcher.readConfig("example", ConfigFactory.empty)
       settings.workRetry === 0
-      settings.autoScaling shouldBe defined
+      settings.autothrottle shouldBe defined
       reporter shouldBe empty
     }
 
@@ -297,16 +297,16 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
 
       val (settings, _) = Dispatcher.readConfig("example", ConfigFactory.parseString(cfgStr))
       settings.workRetry === 29
-      settings.autoScaling shouldBe defined
+      settings.autothrottle shouldBe defined
     }
 
-    "turn off autoScaling if set to off" in {
+    "turn off autothrottle if set to off" in {
       val cfgStr =
         """
             kanaloa {
               dispatchers {
                 example {
-                  autoScaling {
+                  autothrottle {
                     enabled = off
                   }
                 }
@@ -314,7 +314,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
             }
           """
       val (settings, _) = Dispatcher.readConfig("example", ConfigFactory.parseString(cfgStr))
-      settings.autoScaling shouldBe None
+      settings.autothrottle shouldBe None
     }
 
     "turn off circuitBreaker if set to off" in {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
@@ -97,7 +97,7 @@ class MinimalPushingDispatcherIntegration extends IntegrationSpec {
             workerPool {
               startingPoolSize = 8
             }
-            autoScaling {
+            autothrottle {
               enabled = off
             }
             backPressure {
@@ -154,7 +154,7 @@ class PullingDispatcherIntegration extends IntegrationSpec {
 
 }
 
-class AutoScalingWithPushingIntegration extends IntegrationSpec {
+class AutothrottleWithPushingIntegration extends IntegrationSpec {
 
   "pushing dispatcher move to the optimal pool size" in new TestScope {
 
@@ -178,9 +178,9 @@ class AutoScalingWithPushingIntegration extends IntegrationSpec {
               thresholdForExpectedWaitTime = 1h
               maxHistoryLength = 3s
             }
-            autoScaling {
+            autothrottle {
               chanceOfScalingDownWhenFull = 0.1
-              scalingInterval = 100ms
+              resizeInterval = 100ms
               downsizeAfterUnderUtilization = 72h
             }
           }
@@ -210,7 +210,7 @@ class AutoScalingWithPushingIntegration extends IntegrationSpec {
   }
 }
 
-class AutoScalingWithPullingIntegration extends IntegrationSpec {
+class AutothrottleWithPullingIntegration extends IntegrationSpec {
 
   "pulling dispatcher move to the optimal pool size" in new TestScope {
 
@@ -239,9 +239,9 @@ class AutoScalingWithPullingIntegration extends IntegrationSpec {
               thresholdForExpectedWaitTime = 1h
               maxHistoryLength = 3s
             }
-            autoScaling {
+            autothrottle {
               chanceOfScalingDownWhenFull = 0.1
-              scalingInterval = 100ms
+              resizeInterval = 100ms
               downsizeAfterUnderUtilization = 72h
             }
           }
@@ -282,7 +282,7 @@ class AutoScalingWithPullingIntegration extends IntegrationSpec {
   }
 }
 
-class AutoScalingDownSizeWithSparseTrafficIntegration extends IntegrationSpec {
+class AutothrottleDownSizeWithSparseTrafficIntegration extends IntegrationSpec {
   "downsize when the traffic is sparse" in new TestScope {
     val backend = TestActorRef[SimpleBackend]
     val pd = TestActorRef[Dispatcher](PushingDispatcher.props(
@@ -296,8 +296,8 @@ class AutoScalingDownSizeWithSparseTrafficIntegration extends IntegrationSpec {
               startingPoolSize = 10
               minPoolSize = 2
             }
-            autoScaling {
-              scalingInterval = 10ms
+            autothrottle {
+              resizeInterval = 10ms
               downsizeAfterUnderUtilization = 100ms
             }
           }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutoScalingSpec.scala
@@ -7,7 +7,7 @@ import kanaloa.reactive.dispatcher.DurationFunctions._
 import kanaloa.reactive.dispatcher.PerformanceSampler.{PartialUtilization, Sample}
 import kanaloa.reactive.dispatcher.Types.QueueLength
 import kanaloa.reactive.dispatcher.metrics.MetricsCollector
-import kanaloa.reactive.dispatcher.queue.AutoScaling.{AutoScalingStatus, OptimizeOrExplore, PoolSize}
+import kanaloa.reactive.dispatcher.queue.Autothrottler.{AutothrottleStatus, OptimizeOrExplore, PoolSize}
 import kanaloa.reactive.dispatcher.queue.QueueProcessor.{ScaleTo, Shutdown}
 import kanaloa.reactive.dispatcher.queue.Worker.{Idle, Working}
 import kanaloa.reactive.dispatcher.{ResultChecker, ScopeWithActor, SpecWithActorSystem}
@@ -16,76 +16,76 @@ import org.scalatest.concurrent.Eventually
 
 import scala.concurrent.duration._
 
-class AutoScalingSpec extends SpecWithActorSystem with OptionValues with Eventually {
+class AutothrottleSpec extends SpecWithActorSystem with OptionValues with Eventually {
 
   def sample(poolSize: PoolSize) =
     Sample(3, 2.second.ago, 1.second.ago, poolSize, QueueLength(14))
 
-  "AutoScaling" should {
-    "when no history" in new AutoScalingScope {
+  "Autothrottle" should {
+    "when no history" in new AutothrottleScope {
       as ! OptimizeOrExplore
       tProcessor.expectNoMsg(50.milliseconds)
     }
 
-    "record perfLog" in new AutoScalingScope {
+    "record perfLog" in new AutothrottleScope {
       as ! sample(poolSize = 30)
       as ! QueryStatus()
-      val status = expectMsgType[AutoScalingStatus]
+      val status = expectMsgType[AutothrottleStatus]
       status.poolSize should contain(30)
       status.performanceLog.keys should contain(30)
     }
 
-    "update poolsize" in new AutoScalingScope {
+    "update poolsize" in new AutothrottleScope {
       as ! sample(poolSize = 30)
       as ! sample(poolSize = 33)
       as ! sample(poolSize = 35)
       as ! QueryStatus()
-      val status = expectMsgType[AutoScalingStatus]
+      val status = expectMsgType[AutothrottleStatus]
       status.poolSize should contain(35)
       status.performanceLog.keys should contain(33)
     }
 
-    "start an underutilizationStreak" in new AutoScalingScope {
+    "start an underutilizationStreak" in new AutothrottleScope {
       as ! PartialUtilization(3)
       as ! QueryStatus()
-      val status = expectMsgType[AutoScalingStatus]
+      val status = expectMsgType[AutothrottleStatus]
       status.partialUtilization should contain(3)
       status.partialUtilizationStart should not be (empty)
     }
 
-    "stop an underutilizationStreak" in new AutoScalingScope {
+    "stop an underutilizationStreak" in new AutothrottleScope {
       as ! PartialUtilization(3)
       as ! sample(poolSize = 30)
 
       as ! QueryStatus()
-      val status = expectMsgType[AutoScalingStatus]
+      val status = expectMsgType[AutothrottleStatus]
       status.partialUtilization should be(empty)
       status.partialUtilizationStart should be(empty)
     }
 
-    "update an underutilizationStreak to the highest utilization" in new AutoScalingScope {
+    "update an underutilizationStreak to the highest utilization" in new AutothrottleScope {
       as ! PartialUtilization(3)
       as ! QueryStatus()
 
-      val status1 = expectMsgType[AutoScalingStatus]
+      val status1 = expectMsgType[AutothrottleStatus]
 
       as ! PartialUtilization(5)
       as ! QueryStatus()
 
-      val status2 = expectMsgType[AutoScalingStatus]
+      val status2 = expectMsgType[AutothrottleStatus]
 
       as ! PartialUtilization(4)
       as ! QueryStatus()
 
-      val status3 = expectMsgType[AutoScalingStatus]
+      val status3 = expectMsgType[AutothrottleStatus]
 
       status1.partialUtilizationStart should not be (empty)
       status1.partialUtilizationStart should be(status3.partialUtilizationStart)
       status3.partialUtilization should contain(5)
     }
 
-    "explore when currently maxed out and exploration rate is 1" in new AutoScalingScope {
-      val subject = autoScalingRef(alwaysExploreSettings)
+    "explore when currently maxed out and exploration rate is 1" in new AutothrottleScope {
+      val subject = autothrottleRef(alwaysExploreSettings)
       subject ! sample(poolSize = 30)
 
       subject ! OptimizeOrExplore
@@ -95,8 +95,8 @@ class AutoScalingSpec extends SpecWithActorSystem with OptionValues with Eventua
       scaleCmd.reason.value shouldBe "exploring"
     }
 
-    "does not optimize when not currently maxed" in new AutoScalingScope {
-      val subject = autoScalingRef()
+    "does not optimize when not currently maxed" in new AutothrottleScope {
+      val subject = autothrottleRef()
       subject ! sample(poolSize = 30)
 
       subject ! OptimizeOrExplore
@@ -109,8 +109,8 @@ class AutoScalingSpec extends SpecWithActorSystem with OptionValues with Eventua
       tProcessor.expectNoMsg(30.millisecond)
     }
 
-    "optimize towards the faster size when currently maxed out and exploration rate is 0" in new AutoScalingScope {
-      val subject = autoScalingRef(alwaysOptimizeSettings)
+    "optimize towards the faster size when currently maxed out and exploration rate is 0" in new AutothrottleScope {
+      val subject = autothrottleRef(alwaysOptimizeSettings)
       mockBusyHistory(
         subject,
         (30, 3),
@@ -127,8 +127,8 @@ class AutoScalingSpec extends SpecWithActorSystem with OptionValues with Eventua
       scaleCmd.numOfWorkers should be < 45
     }
 
-    "ignore further away sample data when optmizing" in new AutoScalingScope {
-      val subject = autoScalingRef(alwaysOptimizeSettings)
+    "ignore further away sample data when optmizing" in new AutothrottleScope {
+      val subject = autothrottleRef(alwaysOptimizeSettings)
       mockBusyHistory(
         subject,
         (10, 1999), //should be ignored
@@ -151,8 +151,8 @@ class AutoScalingSpec extends SpecWithActorSystem with OptionValues with Eventua
       scaleCmd.numOfWorkers should be < 44
     }
 
-    "downsize if hasn't maxed out for more than relevant period of hours" in new AutoScalingScope {
-      val subject = autoScalingRef(defaultSettings.copy(downsizeAfterUnderUtilization = 10.milliseconds))
+    "downsize if hasn't maxed out for more than relevant period of hours" in new AutothrottleScope {
+      val subject = autothrottleRef(defaultSettings.copy(downsizeAfterUnderUtilization = 10.milliseconds))
 
       subject ! PartialUtilization(5)
       tProcessor.expectNoMsg(20.milliseconds)
@@ -172,11 +172,11 @@ class AutoScalingSpec extends SpecWithActorSystem with OptionValues with Eventua
       )(ResultChecker.expectType))
 
       watch(processor)
-      val autoScaler = system.actorOf(AutoScaling.default(processor, AutoScalingSettings(), MetricsCollector(None)))
-      watch(autoScaler)
+      val autothrottler = system.actorOf(Autothrottler.default(processor, AutothrottleSettings(), MetricsCollector(None)))
+      watch(autothrottler)
       processor ! PoisonPill
 
-      Set(expectMsgType[Terminated].actor, expectMsgType[Terminated].actor) shouldBe Set(processor, autoScaler)
+      Set(expectMsgType[Terminated].actor, expectMsgType[Terminated].actor) shouldBe Set(processor, autothrottler)
     }
 
     "stop itself if the QueueProcessor is shutting down" in new ScopeWithActor() {
@@ -184,7 +184,7 @@ class AutoScalingSpec extends SpecWithActorSystem with OptionValues with Eventua
       val queue = TestProbe()
       val processor = system.actorOf(QueueProcessor.default(queue.ref, backend, ProcessingWorkerPoolSettings(), mc)(ResultChecker.expectType))
       //using 10 minutes to squelch its querying of the QueueProcessor, so that we can do it manually
-      val a = system.actorOf(AutoScaling.default(processor, AutoScalingSettings(scalingInterval = 10.minutes), mc))
+      val a = system.actorOf(Autothrottler.default(processor, AutothrottleSettings(resizeInterval = 10.minutes), mc))
       watch(a)
       a ! PartialUtilization(5)
       processor ! Shutdown(None, 100.milliseconds)
@@ -193,13 +193,13 @@ class AutoScalingSpec extends SpecWithActorSystem with OptionValues with Eventua
   }
 }
 
-class AutoScalingScope(implicit system: ActorSystem)
+class AutothrottleScope(implicit system: ActorSystem)
   extends TestKit(system) with ImplicitSender {
 
   val metricsCollector: ActorRef = MetricsCollector(None) // To be overridden
-  val defaultSettings: AutoScalingSettings = AutoScalingSettings(
+  val defaultSettings: AutothrottleSettings = AutothrottleSettings(
     chanceOfScalingDownWhenFull = 0.3,
-    scalingInterval = 1.hour, //manual action only
+    resizeInterval = 1.hour, //manual action only
     explorationRatio = 0.5,
     downsizeRatio = 0.8,
     downsizeAfterUnderUtilization = 72.hours,
@@ -211,9 +211,9 @@ class AutoScalingScope(implicit system: ActorSystem)
 
   val tProcessor = TestProbe()
 
-  def autoScalingRef(settings: AutoScalingSettings = defaultSettings) = {
+  def autothrottleRef(settings: AutothrottleSettings = defaultSettings) = {
 
-    TestActorRef[AutoScaling](AutoScaling.default(
+    TestActorRef[Autothrottler](Autothrottler.default(
       tProcessor.ref, settings, metricsCollector
     ))
   }
@@ -235,10 +235,10 @@ class AutoScalingScope(implicit system: ActorSystem)
 
   }
 
-  lazy val as = autoScalingRef()
+  lazy val as = autothrottleRef()
 }
 
-object AutoScalingScope {
+object AutothrottleScope {
   import akka.actor.ActorDSL._
 
   def newWorker(busy: Boolean = true)(implicit system: ActorSystem) = actor(new Act {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutothrottlerSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutothrottlerSpec.scala
@@ -85,7 +85,7 @@ class AutothrottleSpec extends SpecWithActorSystem with OptionValues with Eventu
     }
 
     "explore when currently maxed out and exploration rate is 1" in new AutothrottleScope {
-      val subject = autothrottleRef(alwaysExploreSettings)
+      val subject = autothrottlerRef(alwaysExploreSettings)
       subject ! sample(poolSize = 30)
 
       subject ! OptimizeOrExplore
@@ -96,7 +96,7 @@ class AutothrottleSpec extends SpecWithActorSystem with OptionValues with Eventu
     }
 
     "does not optimize when not currently maxed" in new AutothrottleScope {
-      val subject = autothrottleRef()
+      val subject = autothrottlerRef()
       subject ! sample(poolSize = 30)
 
       subject ! OptimizeOrExplore
@@ -110,7 +110,7 @@ class AutothrottleSpec extends SpecWithActorSystem with OptionValues with Eventu
     }
 
     "optimize towards the faster size when currently maxed out and exploration rate is 0" in new AutothrottleScope {
-      val subject = autothrottleRef(alwaysOptimizeSettings)
+      val subject = autothrottlerRef(alwaysOptimizeSettings)
       mockBusyHistory(
         subject,
         (30, 3),
@@ -128,7 +128,7 @@ class AutothrottleSpec extends SpecWithActorSystem with OptionValues with Eventu
     }
 
     "ignore further away sample data when optmizing" in new AutothrottleScope {
-      val subject = autothrottleRef(alwaysOptimizeSettings)
+      val subject = autothrottlerRef(alwaysOptimizeSettings)
       mockBusyHistory(
         subject,
         (10, 1999), //should be ignored
@@ -152,7 +152,7 @@ class AutothrottleSpec extends SpecWithActorSystem with OptionValues with Eventu
     }
 
     "downsize if hasn't maxed out for more than relevant period of hours" in new AutothrottleScope {
-      val subject = autothrottleRef(defaultSettings.copy(downsizeAfterUnderUtilization = 10.milliseconds))
+      val subject = autothrottlerRef(defaultSettings.copy(downsizeAfterUnderUtilization = 10.milliseconds))
 
       subject ! PartialUtilization(5)
       tProcessor.expectNoMsg(20.milliseconds)
@@ -211,7 +211,7 @@ class AutothrottleScope(implicit system: ActorSystem)
 
   val tProcessor = TestProbe()
 
-  def autothrottleRef(settings: AutothrottleSettings = defaultSettings) = {
+  def autothrottlerRef(settings: AutothrottleSettings = defaultSettings) = {
 
     TestActorRef[Autothrottler](Autothrottler.default(
       tProcessor.ref, settings, metricsCollector
@@ -235,7 +235,7 @@ class AutothrottleScope(implicit system: ActorSystem)
 
   }
 
-  lazy val as = autothrottleRef()
+  lazy val as = autothrottlerRef()
 }
 
 object AutothrottleScope {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
@@ -256,9 +256,9 @@ class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backen
 
 }
 
-class ScalingWhenWorkingSpec extends SpecWithActorSystem with Eventually {
+class AutothrottleWhenWorkingSpec extends SpecWithActorSystem with Eventually {
 
-  "scaling" should {
+  "autothrottle" should {
 
     "send PoolSize metric when pool size changes" in new MetricCollectorScope {
 


### PR DESCRIPTION
## Incentive

The word auto scale is actually misleading. It implies that the system can automatically scale up on demand, which isn't the case. It's just throttling the concurrent requests hitting the service. 
