### PR TITLE
fixed the working worker doesnt retire bug

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -106,6 +106,7 @@ kanaloa {
       chanceOfScalingDownWhenFull = 0.1
 
       # Interval between each pool size adjustment attempt
+      # This interval must be longer than the update interval
       resizeInterval = ${kanaloa.default-dispatcher.updateInterval}
 
       # If the workers have not been fully utilized (i.e. all workers are busy) for such length,

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -106,7 +106,7 @@ kanaloa {
       chanceOfScalingDownWhenFull = 0.1
 
       # Interval between each pool size adjustment attempt
-      # This interval must be longer than the update interval
+      # This interval must be at least as long as the update interval
       resizeInterval = ${kanaloa.default-dispatcher.updateInterval}
 
       # If the workers have not been fully utilized (i.e. all workers are busy) for such length,

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
@@ -127,7 +127,7 @@ trait Autothrottler extends Actor with ActorLogging with MessageScheduler {
   }
 
   private def explore(currentSize: PoolSize): ScaleTo = {
-    val change = Math.max(1, Random.nextInt(Math.ceil(currentSize * exploreStepSize).toInt))
+    val change = Math.max(1, Random.nextInt(Math.ceil(currentSize.toDouble * exploreStepSize).toInt))
     if (random.nextDouble() < chanceOfScalingDownWhenFull)
       ScaleTo(currentSize - change, Some("exploring"))
     else

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
@@ -104,7 +104,7 @@ trait Autothrottler extends Actor with ActorLogging with MessageScheduler {
 
   private def optimize(currentSize: PoolSize): ScaleTo = {
 
-    val adjacentDispatchWaits: PerformanceLog = {
+    val adjacentPerformances: PerformanceLog = {
       def adjacency = (size: Int) ⇒ Math.abs(currentSize - size)
       val sizes = perfLog.keys.toSeq
       val numOfSizesEachSide = numOfAdjacentSizesToConsiderDuringOptimization / 2
@@ -113,8 +113,16 @@ trait Autothrottler extends Actor with ActorLogging with MessageScheduler {
       perfLog.filter { case (size, _) ⇒ size >= leftBoundary && size <= rightBoundary }
     }
 
-    val optimalSize = adjacentDispatchWaits.maxBy(_._2)._1
+    log.debug("Optimizing based on performance table: " +
+      adjacentPerformances.toList.sortBy(_._2).takeRight(10).reverse.map(p ⇒ s"Sz: ${p._1} spd: ${p._2 * 100} ").mkString(" | "))
+
+    val optimalSize = adjacentPerformances.maxBy(_._2)._1
+
     val scaleStep = Math.ceil((optimalSize - currentSize).toDouble / 2.0).toInt
+
+    if (scaleStep > 0)
+      log.debug("Optimized to " + (currentSize + scaleStep) + " from " + currentSize)
+
     ScaleTo(currentSize + scaleStep, Some("optimizing"))
   }
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/WorkerRetiringSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/WorkerRetiringSpec.scala
@@ -39,57 +39,6 @@ class WorkerUnregisteringIdleSpec extends WorkerSpec {
   }
 }
 
-class WorkerUnregisteringBusySpec extends WorkerSpec {
-
-  final def withUnregisteringBusyWorker(test: (TestActorRef[Worker], TestProbe, TestProbe, Work) ⇒ Any) {
-    withWorkingWorker(WorkSettings()) { (worker, queueProbe, routeeProbe, work, _) ⇒
-      worker ! Retire //this changes the Worker's state into 'unregisteringbusy'
-      test(worker, queueProbe, routeeProbe, work)
-    }
-  }
-
-  "An UnregisteringBusy Worker" should {
-
-    "status is UnregisteringBusy" in withUnregisteringBusyWorker { (worker, queueProbe, routeeProbe, work) ⇒
-      assertWorkerStatus(worker, Worker.UnregisteringBusy)
-    }
-
-    "reject Work" in withUnregisteringBusyWorker { (worker, queueProbe, routeeProbe, work) ⇒
-      val w = Work("moreWork")
-      worker ! w
-      expectMsg(Rejected(w, "Retiring"))
-    }
-
-    "transition to 'unregisteringIdle' if WorkComplete" in withUnregisteringBusyWorker { (worker, queueProbe, routeeProbe, work) ⇒
-      routeeProbe.reply(Result("finished!"))
-      expectMsg("finished!")
-      assertWorkerStatus(worker, Worker.UnregisteringIdle)
-    }
-
-    "transition to 'unregisteringIdle' Routee dies" in withUnregisteringBusyWorker { (worker, queueProbe, routeeProbe, work) ⇒
-      routeeProbe.ref ! PoisonPill
-      expectMsgType[WorkFailed]
-      assertWorkerStatus(worker, Worker.UnregisteringIdle)
-    }
-
-    "transition to 'unregisteringIdle' if Work fails" in withUnregisteringBusyWorker { (worker, queueProbe, routeeProbe, work) ⇒
-      routeeProbe.reply(Fail("finished!"))
-      expectMsgType[WorkFailed]
-      assertWorkerStatus(worker, Worker.UnregisteringIdle)
-    }
-
-    "transition to 'waitingToTerminate' if Unregistered" in withUnregisteringBusyWorker { (worker, queueProbe, routeeProbe, work) ⇒
-      worker ! Unregistered
-      assertWorkerStatus(worker, Worker.WaitingToTerminate)
-    }
-
-    "transition to 'waitingToTerminate if Terminated(queue)" in withUnregisteringBusyWorker { (worker, queueProbe, routeeProbe, work) ⇒
-      queueProbe.ref ! PoisonPill
-      assertWorkerStatus(worker, Worker.WaitingToTerminate)
-    }
-  }
-}
-
 class WorkerWaitingToTerminateSpec extends WorkerSpec {
 
   final def withTerminatingWorker(settings: WorkSettings = WorkSettings())(test: (TestActorRef[Worker], TestProbe, TestProbe, Work) ⇒ Any) {


### PR DESCRIPTION
Found out that with the new code working worker does not retire entirely, they will remain in the pool forever. I think it's related to the `UnregisteringBusy` state.
Then I realized that  it's not needed, when a worker is busy, it won't be in the `queue`'s waiting list and thus no need to unregister from it. So I removed it and go directly to `WaitingTermination` state, which fixed the problem. 
I also changed the workerPool back to a list, we need to maintain the creation sequence. 
