### PR TITLE
removed last vestiges of unregisteringBusy from Worker

### DIFF
--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/WorkerWorkingSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/WorkerWorkingSpec.scala
@@ -69,11 +69,10 @@ class WorkerWorkingSpec extends WorkerSpec {
       metricCollectorProbe.expectMsg(Metric.WorkTimedOut)
     }
 
-    "fail Work, transitions to 'unregisteringIdle' if Terminated(routee)" in withWorkingWorker() { (worker, queueProbe, routeeProbe, work, _) ⇒
+    "fail Work and terminate if Terminated(routee)" in withWorkingWorker() { (worker, queueProbe, routeeProbe, work, _) ⇒
       routeeProbe.ref ! PoisonPill
       expectMsgType[WorkFailed]
-      queueProbe.expectMsg(Unregister(worker))
-      assertWorkerStatus(worker, UnregisteringIdle)
+      expectTerminated(worker)
     }
 
     "transition to 'waitingToTerminate' if Terminated(queue)" in withWorkingWorker() { (worker, queueProbe, _, work, _) ⇒


### PR DESCRIPTION
fixes #127 

Just removing the parameter from `handleRouteeResponse` which allowed for different action when a Routee died.  This was to allow a worker to unregister in this case, however, as noted, this is not needed.  Now, if a Routee dies while Work is executing, the Worker will fail the Work and terminate.
