### PR TITLE
when remote backend is down

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -25,7 +25,7 @@ kanaloa {
       healthCheckInterval = 5s
 
       # whether or not log failures when retrieving routee
-      logRouteeRetrievalError = true
+      logRouteeRetrievalError = false
     }
 
     circuitBreaker {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -22,7 +22,7 @@ kanaloa {
       maxPoolSize = 400
 
       # check if worker pool is in a healthy state every such interval.
-      healthCheckInterval = 1s
+      healthCheckInterval = 5s
 
       # whether or not log failures when retrieving routee
       logRouteeRetrievalError = true

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
@@ -34,7 +34,9 @@ class QueueProcessor(
   override val supervisorStrategy = SupervisorStrategy.stoppingStrategy
 
   override def preStart(): Unit = {
+
     super.preStart()
+    metricsCollector ! Metric.PoolSize(0)
     (1 to settings.startingPoolSize).foreach(_ ⇒ retrieveRoutee())
     context watch queue
   }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
@@ -135,7 +135,7 @@ class QueueProcessor(
 
   private def healthCheck(): Unit = {
     if (tryCreateWorkersIfNeeded(settings.minPoolSize - currentWorkers))
-      log.warning("Number of workers in pool is below minimum. Trying to replenish. ")
+      log.debug("Number of workers in pool is below minimum. Trying to replenish.")
   }
   /**
    *

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
@@ -7,6 +7,7 @@ import akka.testkit.TestActor.AutoPilot
 import akka.testkit.{TestActorRef, TestActor, TestProbe}
 import kanaloa.reactive.dispatcher.ApiProtocol.{ShutdownGracefully, ShutdownForcefully, QueryStatus, ShutdownSuccessfully}
 import kanaloa.reactive.dispatcher.metrics.Metric
+import kanaloa.reactive.dispatcher.metrics.Metric.PoolSize
 import kanaloa.reactive.dispatcher.queue.Queue.Retire
 import kanaloa.reactive.dispatcher.queue.QueueProcessor.{ScaleTo, Shutdown, ShuttingDown}
 import kanaloa.reactive.dispatcher._
@@ -55,6 +56,10 @@ class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backen
     "create Workers on startup" in withQueueProcessor() { (qp, queueProbe, metricsCollector, testBackend, workerFactory) ⇒
       qp.underlyingActor.workerPool should have size 5
       testBackend.timesInvoked shouldBe 5
+    }
+
+    "report pool size on startup" in withQueueProcessor() { (qp, queueProbe, metricsCollector, testBackend, workerFactory) ⇒
+      metricsCollector.expectMsg(PoolSize(0))
     }
 
     "scale workers up" in withQueueProcessor() { (qp, queueProbe, metricsCollector, testBackend, workerFactory) ⇒


### PR DESCRIPTION
The combination of health check and warning log will keep creating warnings. As a temporary fix, we extend the health check interval and lower the log level. The poolsize can be monitored through graphana. 
The long term fix is #123 
