### PR TITLE
fixing inbound traffic metrics

### DIFF
--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Dispatcher.scala
@@ -134,7 +134,9 @@ case class PushingDispatcher(
   override def extraReceive: Receive = {
     case EnqueueRejected(enqueued, reason) ⇒ enqueued.sendResultsTo.foreach(_ ! WorkRejected(reason.toString))
     case r: DroppingRate                   ⇒ droppingRate = r
-    case m                                 ⇒ dropOrEnqueue(m, sender)
+    case m ⇒
+      metricsCollector ! Metric.WorkReceived
+      dropOrEnqueue(m, sender)
   }
 
   private def dropOrEnqueue(m: Any, replyTo: ActorRef): Unit = {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Metric.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/Metric.scala
@@ -7,7 +7,7 @@ sealed trait Metric
 object Metric {
   sealed trait Event extends Metric
 
-  case object WorkEnqueued extends Event
+  case object WorkReceived extends Event
   case object WorkRejected extends Event
 
   case object WorkTimedOut extends Event

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/StatsDReporter.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/metrics/StatsDReporter.scala
@@ -43,7 +43,7 @@ class StatsDReporter(
   val failureSampleRate: Double = 1.0
 
   def report(metric: Metric): Unit = metric match {
-    case WorkEnqueued ⇒ increment("queue.enqueued")
+    case WorkReceived ⇒ increment("queue.enqueued")
     case WorkRejected ⇒ increment("queue.enqueueRejected", Math.min(1d, eventSampleRate * 3d))
 
     case WorkCompleted(processTime) ⇒

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -603,7 +603,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 9,
+          "id": 12,
           "legend": {
             "avg": false,
             "current": false,


### PR DESCRIPTION
Before this PR the inbound traffic is reported when a work is enqueued in the Queue, but since now `PushingDispatcher` can drop work, it's no longer the accurate inbound traffic. So now the report is trigger in two places:
1) in PushingDispatcher when work received and
2)  in QueueOfIterator when a work is pulled in from the iterator. This is used by the PullingDispatcher. 
