### PR TITLE
Fix metrics report

### DIFF
--- a/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
@@ -3,10 +3,13 @@ package kanaloa.reactive.dispatcher
 import java.time.{LocalDateTime ⇒ Time}
 
 import akka.actor.{Terminated, ActorRef, Actor}
+import kanaloa.reactive.dispatcher.ApiProtocol.QueryStatus
 import kanaloa.reactive.dispatcher.Types.{Speed, QueueLength}
 import kanaloa.reactive.dispatcher.metrics.Metric._
 import PerformanceSampler._
 import kanaloa.reactive.dispatcher.metrics.{Metric, MetricsCollector}
+import kanaloa.reactive.dispatcher.queue.Queue
+import kanaloa.reactive.dispatcher.queue.Queue.Status
 import kanaloa.util.Java8TimeExtensions._
 
 import scala.concurrent.duration._
@@ -70,7 +73,7 @@ private[dispatcher] trait PerformanceSampler extends Actor {
     report(WorkQueueLength(queueLength.value))
 
   def fullyUtilized(s: QueueStatus): Receive = handleSubscriptions orElse {
-    case DispatchResult(idle, workLeft, isFullyUtilized) ⇒
+    case Queue.Status(idle, workLeft, isFullyUtilized) ⇒
       reportQueueLength(workLeft)
       if (!isFullyUtilized) {
         val (rpt, _) = tryComplete(s)
@@ -104,13 +107,13 @@ private[dispatcher] trait PerformanceSampler extends Actor {
   }
 
   def partialUtilized(poolSize: Int): Receive = handleSubscriptions orElse {
-    case DispatchResult(idle, workLeft, isFullyUtilized) if isFullyUtilized ⇒
+    case Queue.Status(idle, workLeft, isFullyUtilized) if isFullyUtilized ⇒
       context become fullyUtilized(
         QueueStatus(poolSize = poolSize, queueLength = workLeft)
       )
       reportQueueLength(workLeft)
 
-    case DispatchResult(idle, _, _) ⇒
+    case Queue.Status(idle, _, _) ⇒
       publishUtilization(idle, poolSize)
 
     case metric: Metric ⇒
@@ -118,7 +121,7 @@ private[dispatcher] trait PerformanceSampler extends Actor {
         case PoolSize(s) ⇒
           context become partialUtilized(s)
       }
-    case AddSample ⇒
+    case AddSample ⇒ //no sample is produced in the partial utilized state
   }
 
   /**
@@ -147,8 +150,6 @@ private[dispatcher] object PerformanceSampler {
 
   case class Subscribe(actorRef: ActorRef)
   case class Unsubscribe(actorRef: ActorRef)
-
-  case class DispatchResult(workersLeft: Int, queueLength: QueueLength, fullyUtilized: Boolean)
 
   /**
    *

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
@@ -107,14 +107,14 @@ private[dispatcher] trait PerformanceSampler extends Actor {
   }
 
   def partialUtilized(poolSize: Int): Receive = handleSubscriptions orElse {
-    case Queue.Status(idle, workLeft, isFullyUtilized) if isFullyUtilized ⇒
-      context become fullyUtilized(
-        QueueStatus(poolSize = poolSize, queueLength = workLeft)
-      )
-      reportQueueLength(workLeft)
-
-    case Queue.Status(idle, _, _) ⇒
-      publishUtilization(idle, poolSize)
+    case Queue.Status(idle, queueLength, isFullyUtilized) ⇒
+      if (isFullyUtilized) {
+        context become fullyUtilized(
+          QueueStatus(poolSize = poolSize, queueLength = queueLength)
+        )
+      } else
+        publishUtilization(idle, poolSize)
+      reportQueueLength(queueLength)
 
     case metric: Metric ⇒
       handle(metric) {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -16,9 +16,10 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
   def defaultWorkSettings: WorkSettings
   def metricsCollector: ActorRef
 
-  final def receive = processing(InternalState())
+  val initialState = InternalState()
+  final def receive = processing(initialState)
 
-  metricsCollector ! Metric.WorkQueueLength(0)
+  metricsCollector ! statusOf(initialState)
 
   final def processing(state: InternalState): Receive =
     handleWork(state, processing) orElse {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Queue.scala
@@ -5,7 +5,7 @@ import kanaloa.reactive.dispatcher.ApiProtocol.{QueryStatus, WorkRejected}
 import kanaloa.reactive.dispatcher.PerformanceSampler
 import kanaloa.reactive.dispatcher.Types.QueueLength
 import kanaloa.reactive.dispatcher.metrics.{MetricsCollector, Metric}
-import kanaloa.reactive.dispatcher.queue.Queue.{Status, _}
+import kanaloa.reactive.dispatcher.queue.Queue.{InternalState, _}
 import kanaloa.util.MessageScheduler
 
 import scala.annotation.tailrec
@@ -16,16 +16,16 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
   def defaultWorkSettings: WorkSettings
   def metricsCollector: ActorRef
 
-  final def receive = processing(Status())
+  final def receive = processing(InternalState())
 
   metricsCollector ! Metric.WorkQueueLength(0)
 
-  final def processing(status: Status): Receive =
-    handleWork(status, processing) orElse {
+  final def processing(state: InternalState): Receive =
+    handleWork(state, processing) orElse {
       case e @ Enqueue(workMessage, sendAcks, sendResultsTo) ⇒
         val newWork = Work(workMessage, sendResultsTo, defaultWorkSettings)
-        val newBuffer: ScalaQueue[Work] = status.workBuffer.enqueue(newWork)
-        val newStatus: Status = dispatchWork(status.copy(workBuffer = newBuffer))
+        val newBuffer: ScalaQueue[Work] = state.workBuffer.enqueue(newWork)
+        val newStatus: InternalState = dispatchWork(state.copy(workBuffer = newBuffer))
         if (sendAcks) {
           sender() ! WorkEnqueued
         }
@@ -33,7 +33,7 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
 
       case Retire(timeout) ⇒
         log.debug("Queue commanded to retire")
-        val newStatus = dispatchWork(status, retiring = true)
+        val newStatus = dispatchWork(state, retiring = true)
         context become retiring(newStatus)
         newStatus.queuedWorkers.foreach { qw ⇒
           qw ! NoWorkLeft
@@ -42,44 +42,44 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
         delayedMsg(timeout, RetiringTimeout)
     }
 
-  final def retiring(status: Status): Receive =
-    if (status.workBuffer.isEmpty) {
-      finish(status, s"Queue successfully retired")
+  final def retiring(state: InternalState): Receive =
+    if (state.workBuffer.isEmpty) {
+      finish(state, s"Queue successfully retired")
       PartialFunction.empty //doesn't matter after finish, but is required by the api.
-    } else handleWork(status, retiring) orElse {
+    } else handleWork(state, retiring) orElse {
       case e @ Enqueue(_, _, _) ⇒ sender() ! EnqueueRejected(e, Queue.EnqueueRejected.Retiring)
-      case RetiringTimeout      ⇒ finish(status, "Forcefully retire after timed out")
+      case RetiringTimeout      ⇒ finish(state, "Forcefully retire after timed out")
     }
 
-  private def finish(status: Status, withMessage: String): Unit = {
-    log.info(withMessage + s"- ${status.countOfWorkSent} work sent.")
-    status.queuedWorkers.foreach(_ ! NoWorkLeft)
+  private def finish(state: InternalState, withMessage: String): Unit = {
+    log.info(withMessage + s"- ${state.countOfWorkSent} work sent.")
+    state.queuedWorkers.foreach(_ ! NoWorkLeft)
     context stop self
   }
 
-  private def handleWork(status: Status, nextContext: Status ⇒ Receive): Receive = {
-    def dispatchWorkAndBecome(status: Status, newContext: Status ⇒ Receive): Unit = {
-      val newStatus = dispatchWork(status)
+  private def handleWork(state: InternalState, nextContext: InternalState ⇒ Receive): Receive = {
+    def dispatchWorkAndBecome(state: InternalState, newContext: InternalState ⇒ Receive): Unit = {
+      val newStatus = dispatchWork(state)
       context become newContext(newStatus)
     }
 
     {
       case RequestWork(requester) ⇒
         context watch requester
-        dispatchWorkAndBecome(status.copy(queuedWorkers = status.queuedWorkers.enqueue(requester)), nextContext)
+        dispatchWorkAndBecome(state.copy(queuedWorkers = state.queuedWorkers.enqueue(requester)), nextContext)
 
       case Unregister(worker) ⇒
-        dispatchWorkAndBecome(status.copy(queuedWorkers = status.queuedWorkers.filterNot(_ == worker)), nextContext)
+        dispatchWorkAndBecome(state.copy(queuedWorkers = state.queuedWorkers.filterNot(_ == worker)), nextContext)
         worker ! Unregistered
 
       case Terminated(worker) ⇒
-        context become nextContext(status.copy(queuedWorkers = status.queuedWorkers.filter(_ != worker)))
+        context become nextContext(state.copy(queuedWorkers = state.queuedWorkers.filter(_ != worker)))
 
       case Rejected(w, reason) ⇒
         log.debug(s"work rejected by worker, reason given by worker is '$reason'")
-        dispatchWorkAndBecome(status.copy(workBuffer = status.workBuffer.enqueue(w)), nextContext)
+        dispatchWorkAndBecome(state.copy(workBuffer = state.workBuffer.enqueue(w)), nextContext)
 
-      case qs: QueryStatus ⇒ qs reply status
+      case qs: QueryStatus ⇒ qs reply statusOf(state)
     }
   }
 
@@ -89,38 +89,40 @@ trait Queue extends Actor with ActorLogging with MessageScheduler {
    * Note that the workers left in the worker queue after dispatch are the only ones
    * that counts as idle workers.
    *
-   * @param status
+   * @param state
    * @param dispatched
    * @param retiring
    * @return
    */
   @tailrec
-  protected final def dispatchWork(status: Status, dispatched: Int = 0, retiring: Boolean = false): Status = {
-    if (status.workBuffer.isEmpty && !status.queuedWorkers.isEmpty && !retiring) onQueuedWorkExhausted()
-    (for (
-      (worker, queuedWorkers) ← status.queuedWorkers.dequeueOption;
-      (work, workBuffer) ← status.workBuffer.dequeueOption
-    ) yield {
+  protected final def dispatchWork(state: InternalState, dispatched: Int = 0, retiring: Boolean = false): InternalState = {
+    if (state.workBuffer.isEmpty && !state.queuedWorkers.isEmpty && !retiring) onQueuedWorkExhausted()
+    (for {
+      (worker, queuedWorkers) ← state.queuedWorkers.dequeueOption
+      (work, workBuffer) ← state.workBuffer.dequeueOption
+    } yield {
       worker ! work
       context unwatch worker
-      status.copy(queuedWorkers = queuedWorkers, workBuffer = workBuffer, countOfWorkSent = status.countOfWorkSent + 1)
+      state.copy(queuedWorkers = queuedWorkers, workBuffer = workBuffer, countOfWorkSent = state.countOfWorkSent + 1)
     }) match {
-      case Some(newStatus) ⇒ dispatchWork(newStatus, dispatched + 1, retiring) //actually in most cases, either works queue or workers queue is empty after one dispatch
+      case Some(newState) ⇒ dispatchWork(newState, dispatched + 1, retiring) //actually in most cases, either works queue or workers queue is empty after one dispatch
       case None ⇒
-        metricsCollector ! PerformanceSampler.DispatchResult(status.queuedWorkers.length, QueueLength(status.workBuffer.length), fullyUtilized(status))
-        status
+        metricsCollector ! statusOf(state)
+        state
     }
   }
 
-  def fullyUtilized(status: Status): Boolean
+  def fullyUtilized(state: InternalState): Boolean
   def onQueuedWorkExhausted(): Unit = ()
+  private def statusOf(state: InternalState): Queue.Status =
+    Queue.Status(state.queuedWorkers.length, QueueLength(state.workBuffer.length), fullyUtilized(state))
 }
 
 case class DefaultQueue(
   defaultWorkSettings: WorkSettings,
   metricsCollector:    ActorRef
 ) extends Queue {
-  def fullyUtilized(status: Status): Boolean = status.queuedWorkers.length == 0 && status.workBuffer.length > 0
+  def fullyUtilized(state: InternalState): Boolean = state.queuedWorkers.length == 0 && state.workBuffer.length > 0
 }
 
 class QueueOfIterator(
@@ -134,7 +136,7 @@ class QueueOfIterator(
   val enqueuer = context.actorOf(enqueueerProps(iterator, sendResultsTo, self, metricsCollector))
 
   /**
-   * Determines if a status indicates the workers pool are fully utilized.
+   * Determines if a state indicates the workers pool are fully utilized.
    * This is different from the default pushing [[DefaultQueue]]
    * for a QueueOfIterator, it only gets work when there is at least one queued worker,
    * which means there is a significant chance a second worker comes in before
@@ -144,10 +146,10 @@ class QueueOfIterator(
    * Todo: Right now we lack the insight of how to set this up correctly so I'd rather have
    * it hard coded for now than allowing our users to tweak it without giving them any guidance
    *
-   * @param status
+   * @param state
    * @return
    */
-  def fullyUtilized(status: Status): Boolean = status.queuedWorkers.length <= 2
+  def fullyUtilized(state: InternalState): Boolean = state.queuedWorkers.length <= 2
 
   override def onQueuedWorkExhausted(): Unit = enqueuer ! EnqueueMore
 }
@@ -228,11 +230,19 @@ object Queue {
 
   private case object RetiringTimeout
 
-  protected[queue] case class Status(
+  protected[queue] case class InternalState(
     workBuffer:      ScalaQueue[Work]     = ScalaQueue.empty,
     queuedWorkers:   ScalaQueue[ActorRef] = ScalaQueue.empty,
     countOfWorkSent: Long                 = 0
   )
+
+  /**
+   * Public status of the queue
+   * @param idleWorkers workers that are waiting for work
+   * @param queueLength work in the queue waiting to be picked up by workers
+   * @param fullyUtilized are all workers in the worker pool utilized
+   */
+  case class Status(idleWorkers: Int, queueLength: QueueLength, fullyUtilized: Boolean)
 
   def ofIterable(
     iterable:           Iterable[_],

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
@@ -56,7 +56,6 @@ class QueueProcessor(
 
     case RouteeRetrieved(routee) ⇒
       createWorker(routee)
-      metricsCollector ! Metric.PoolSize(workerPool.size)
 
     case RouteeFailed(ex) ⇒
       inflightCreations -= 1
@@ -123,7 +122,7 @@ class QueueProcessor(
   private def removeWorker(worker: ActorRef): Unit = {
     context.unwatch(worker)
     workerPool = workerPool.filter(_ != worker)
-    metricsCollector ! Metric.PoolSize(workerPool.size)
+    metricsCollector ! Metric.PoolSize(workerPool.length)
   }
 
   private def retrieveRoutee(): Unit = {
@@ -158,6 +157,7 @@ class QueueProcessor(
     context watch worker
 
     workerPool = workerPool :+ worker
+    metricsCollector ! Metric.PoolSize(workerPool.length)
     inflightCreations -= 1
   }
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
@@ -3,6 +3,7 @@ package kanaloa.reactive.dispatcher.queue
 import akka.actor._
 import kanaloa.reactive.dispatcher.ApiProtocol._
 import kanaloa.reactive.dispatcher.metrics.Metric
+import kanaloa.reactive.dispatcher.metrics.Metric.PoolSize
 import kanaloa.reactive.dispatcher.queue.Queue.Retire
 import kanaloa.reactive.dispatcher.queue.QueueProcessor._
 import kanaloa.reactive.dispatcher.{Backend, ResultChecker}
@@ -66,7 +67,9 @@ class QueueProcessor(
       removeWorker(worker)
       healthCheck()
 
-    case HealthCheck ⇒ healthCheck()
+    case HealthCheck ⇒
+      metricsCollector ! PoolSize(workerPool.length) //also take the opportunity to report PoolSize, this is needed because statsD metrics report is not reliable
+      healthCheck()
 
     //if the Queue terminated, time to shut stuff down.
     case Terminated(`queue`) ⇒

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
@@ -244,16 +244,6 @@ class QueueScope(implicit system: ActorSystem) extends ScopeWithQueue {
     system.actorOf(processorProps)
   }
 
-  def waitForWorkerRegistration(queue: QueueRef, numberOfWorkers: Int): Unit = {
-    queue ! QueryStatus()
-    fishForMessage(500.millisecond, "wait for workers to register") {
-      case qs: InternalState ⇒
-        val registered = qs.queuedWorkers.size == numberOfWorkers
-        if (!registered) queue ! QueryStatus()
-        registered
-    }
-  }
-
   def iteratorQueue(
     iterator:      Iterator[String],
     workSetting:   WorkSettings     = WorkSettings(),

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
@@ -65,10 +65,9 @@ class QueueSpec extends SpecWithActorSystem {
     "does not retrieve work without workers" in new QueueScope with Backends with MockitoSugar with Eventually {
       import org.mockito.Mockito._
       val iterator = mock[Iterator[String]]
-      val queue = system.actorOf(Queue.ofIterator(iterator, metricsCollector, WorkSettings()))
-      queue ! QueryStatus()
-      expectMsgType[Queue.Status]
+      val queue = system.actorOf(Queue.ofIterator(iterator, metricsCollector, WorkSettings(), Some(self)))
 
+      expectNoMsg(40.milliseconds)
       verifyNoMoreInteractions(iterator)
 
     }
@@ -248,7 +247,7 @@ class QueueScope(implicit system: ActorSystem) extends ScopeWithQueue {
   def waitForWorkerRegistration(queue: QueueRef, numberOfWorkers: Int): Unit = {
     queue ! QueryStatus()
     fishForMessage(500.millisecond, "wait for workers to register") {
-      case qs: Status ⇒
+      case qs: InternalState ⇒
         val registered = qs.queuedWorkers.size == numberOfWorkers
         if (!registered) queue ! QueryStatus()
         registered

--- a/stress/frontend/src/main/resources/stressTestInfra.conf
+++ b/stress/frontend/src/main/resources/stressTestInfra.conf
@@ -3,7 +3,6 @@ optimal-throughput =  200    //the opitmal throughput (msg / second) the backend
 
 use-kanaloa = true  //run test with kanaloa?
 
-
 kanaloa {
 
   default-dispatcher {
@@ -29,6 +28,16 @@ kanaloa {
       durationOfBurstAllowed = 3s
     }
 
+    metrics {
+      enabled = on // turn it off if you don't have a statsD server and hostname set as an env var KANALOA_STRESS_STATSD_HOST
+      statsd {
+        namespace = kanaloa-stress
+        host = ${?KANALOA_STRESS_STATSD_HOST}
+        eventSampleRate = 0.25
+      }
+
+
+    }
   }
 
 }

--- a/stress/frontend/src/main/scala/com/iheart/kanaloa/stress/http/StressHttpFrontend.scala
+++ b/stress/frontend/src/main/scala/com/iheart/kanaloa/stress/http/StressHttpFrontend.scala
@@ -15,9 +15,9 @@ import kanaloa.reactive.dispatcher.PushingDispatcher
 import scala.concurrent.duration._
 
 object StressHttpFrontend extends App {
-  val cfg = ConfigFactory.parseResources("stressTestInfra.conf")
+  val cfg = ConfigFactory.load("stressTestInfra.conf")
 
-  implicit val system = ActorSystem("Stress-Tests", cfg)
+  implicit val system = ActorSystem("Stress-Tests", cfg.resolve())
   implicit val materializer = ActorMaterializer()
   implicit val execCtx = system.dispatcher
   implicit val timeout = Timeout(100.seconds)


### PR DESCRIPTION
Fixes #137 
Currently some of the metrics report is triggered only value change, but given the statsD's UDP nature, it's likely that the last state gets lost. So I added a period report send to both `Queue` and `QueueProcessor` so ensure that graphana reflects the current queue state accurately . 
I also added the config to report statsD during gatling stress tests. 
Also some code refactor to clarify the intentions. 

Update: I also included a fix for queuelength and drop rate metrics report fix #139 
