### PR TITLE
Fix vicious cycle: iterator queue keeps recreating failing workers 

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -25,7 +25,10 @@ kanaloa {
       healthCheckInterval = 5s
 
       # whether or not log failures when retrieving routee
-      logRouteeRetrievalError = false
+      logRouteeRetrievalError = true
+
+      # whether or not to shutdown the whole dispatcher when all workers died
+      shutdownOnAllWorkerDeath = true
     }
 
     circuitBreaker {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -29,6 +29,9 @@ kanaloa {
 
       # whether or not to shutdown the whole dispatcher when all workers died
       shutdownOnAllWorkerDeath = true
+
+      # default timeout for shutingdown
+      defaultShutdownTimeout = 30s
     }
 
     circuitBreaker {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
@@ -168,7 +168,6 @@ private[dispatcher] object PerformanceSampler {
     workDone:    Int         = 0,
     start:       Time        = Time.now,
     poolSize:    Int         = 0
-
   ) {
 
     def toSample(minSampleDuration: Duration): Option[Sample] = {

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/QueueProcessor.scala
@@ -65,7 +65,6 @@ class QueueProcessor(
 
     case Terminated(worker) if workerPool.contains(worker) ⇒
       removeWorker(worker)
-      healthCheck()
 
     case HealthCheck ⇒
       metricsCollector ! PoolSize(workerPool.length) //also take the opportunity to report PoolSize, this is needed because statsD metrics report is not reliable

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -35,11 +35,13 @@ package kanaloa.reactive.dispatcher.queue {
    * @param minPoolSize
    */
   case class ProcessingWorkerPoolSettings(
-    startingPoolSize:        Int            = 5,
-    minPoolSize:             Int            = 3,
-    maxPoolSize:             Int            = 400,
-    healthCheckInterval:     FiniteDuration = 1.seconds,
-    logRouteeRetrievalError: Boolean        = true
+    startingPoolSize:         Int            = 5,
+    minPoolSize:              Int            = 3,
+    maxPoolSize:              Int            = 400,
+    healthCheckInterval:      FiniteDuration = 1.seconds,
+    logRouteeRetrievalError:  Boolean        = true,
+    shutdownOnAllWorkerDeath: Boolean        = true
+
   )
 
   /**

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -40,8 +40,8 @@ package kanaloa.reactive.dispatcher.queue {
     maxPoolSize:              Int            = 400,
     healthCheckInterval:      FiniteDuration = 1.seconds,
     logRouteeRetrievalError:  Boolean        = true,
-    shutdownOnAllWorkerDeath: Boolean        = true
-
+    shutdownOnAllWorkerDeath: Boolean        = true,
+    defaultShutdownTimeout:   FiniteDuration = 30.seconds
   )
 
   /**

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/Backends.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/Backends.scala
@@ -1,9 +1,13 @@
 package kanaloa.reactive.dispatcher
 
-import akka.actor.{ActorRef, ActorRefFactory}
+import akka.actor.Actor.Receive
+import akka.actor._
 import akka.testkit.{TestActors, TestProbe}
+import kanaloa.reactive.dispatcher.Backends.SuicidalActor
+import kanaloa.reactive.dispatcher.IntegrationTests.Success
 import kanaloa.reactive.dispatcher.queue._
 
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Promise, ExecutionContext, Future}
 
 trait Backends {
@@ -11,4 +15,25 @@ trait Backends {
     def apply(f: ActorRefFactory): Future[ActorRef] = promise.future
   }
 
+  def processTimeBackend(processTime: FiniteDuration): Backend = Backends.delayedProcessorProps(processTime)
+
+  def suicidal(delay: FiniteDuration): Backend = Props(classOf[SuicidalActor], delay)
+}
+
+object Backends {
+  class SuicidalActor(delay: FiniteDuration) extends Actor {
+    import context.dispatcher
+    context.system.scheduler.scheduleOnce(delay, self, PoisonPill)
+    def receive: Receive = PartialFunction.empty
+  }
+
+  class DelayedProcessor(processTime: FiniteDuration) extends Actor {
+    import context.dispatcher
+    override def receive: Receive = {
+      case m ⇒
+        context.system.scheduler.scheduleOnce(processTime, sender, Success)
+    }
+  }
+
+  def delayedProcessorProps(processTime: FiniteDuration): Props = Props(new DelayedProcessor(processTime))
 }

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/IteratorQueueSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/IteratorQueueSpec.scala
@@ -1,0 +1,70 @@
+package kanaloa.reactive.dispatcher.queue
+
+import kanaloa.reactive.dispatcher.ApiProtocol.ShutdownSuccessfully
+import kanaloa.reactive.dispatcher.{SpecWithActorSystem, Backends}
+import kanaloa.reactive.dispatcher.queue.QueueProcessor.Shutdown
+import kanaloa.reactive.dispatcher.queue.TestUtils._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.mock.MockitoSugar
+
+import concurrent.duration._
+
+class IteratorQueueSpec extends SpecWithActorSystem {
+  "Iterator Queue" should {
+    "Process through a list of tasks in sequence with one worker" in new QueueScope {
+      val queueProcessor = initQueue(iteratorQueue(List("a", "b", "c").iterator))
+
+      delegatee.expectMsg(DelegateeMessage("a"))
+      delegatee.reply(MessageProcessed("a"))
+      delegatee.expectMsg(DelegateeMessage("b"))
+      delegatee.reply(MessageProcessed("b"))
+      delegatee.expectMsg(DelegateeMessage("c"))
+      delegatee.reply(MessageProcessed("c"))
+    }
+
+    "shutdown with all outstanding work done from the queue side" in new QueueScope {
+      val queueProcessor = initQueue(iteratorQueue(List("a", "b", "c", "d").iterator, sendResultsTo = Some(self)))
+
+      delegatee.expectMsg(DelegateeMessage("a"))
+      delegatee.reply(MessageProcessed("a"))
+      delegatee.expectMsg(DelegateeMessage("b"))
+
+      queueProcessor ! Shutdown(Some(self))
+
+      expectMsg("a")
+      expectNoMsg(100.milliseconds) //shouldn't shutdown until the last work is done
+
+      delegatee.reply(MessageProcessed("b"))
+
+      expectMsg("b")
+
+      expectMsg(ShutdownSuccessfully)
+
+    }
+
+    "abandon work when delegatee times out" in new QueueScope {
+      val queueProcessor = initQueue(iteratorQueue(List("a", "b").iterator, WorkSettings(timeout = 288.milliseconds)))
+
+      delegatee.expectMsg(DelegateeMessage("a"))
+
+      delegatee.expectNoMsg(250.milliseconds)
+
+      delegatee.expectMsg(DelegateeMessage("b"))
+      watch(queueProcessor)
+      queueProcessor ! Shutdown
+
+      expectTerminated(queueProcessor)
+    }
+
+    "does not retrieve work without workers" in new QueueScope with Backends with MockitoSugar with Eventually {
+      import org.mockito.Mockito._
+      val iterator = mock[Iterator[String]]
+      val queue = system.actorOf(Queue.ofIterator(iterator, metricsCollector, WorkSettings(), Some(self)))
+
+      expectNoMsg(40.milliseconds)
+      verifyNoMoreInteractions(iterator)
+
+    }
+
+  }
+}

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
@@ -23,7 +23,7 @@ class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backen
 
   type QueueTest = (TestActorRef[QueueProcessor], TestProbe, TestProbe, TestBackend, TestWorkerFactory) ⇒ Any
 
-  def withQueueProcessor(poolSettings: ProcessingWorkerPoolSettings = ProcessingWorkerPoolSettings())(test: QueueTest) {
+  def withQueueProcessor(poolSettings: ProcessingWorkerPoolSettings = ProcessingWorkerPoolSettings(defaultShutdownTimeout = 500.milliseconds))(test: QueueTest) {
 
     val queueProbe = TestProbe("queue")
     val testBackend = new TestBackend()

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueSpec.scala
@@ -15,65 +15,6 @@ import scala.concurrent.duration._
 import scala.util.Random
 
 class QueueSpec extends SpecWithActorSystem {
-
-  "Iterator Queue" should {
-    "Process through a list of tasks in sequence with one worker" in new QueueScope {
-      val queueProcessor = initQueue(iteratorQueue(List("a", "b", "c").iterator))
-
-      delegatee.expectMsg(DelegateeMessage("a"))
-      delegatee.reply(MessageProcessed("a"))
-      delegatee.expectMsg(DelegateeMessage("b"))
-      delegatee.reply(MessageProcessed("b"))
-      delegatee.expectMsg(DelegateeMessage("c"))
-      delegatee.reply(MessageProcessed("c"))
-    }
-
-    "shutdown with all outstanding work done from the queue side" in new QueueScope {
-      val queueProcessor = initQueue(iteratorQueue(List("a", "b", "c", "d").iterator, sendResultsTo = Some(self)))
-
-      delegatee.expectMsg(DelegateeMessage("a"))
-      delegatee.reply(MessageProcessed("a"))
-      delegatee.expectMsg(DelegateeMessage("b"))
-
-      queueProcessor ! Shutdown(Some(self))
-
-      expectMsg("a")
-      expectNoMsg(100.milliseconds) //shouldn't shutdown until the last work is done
-
-      delegatee.reply(MessageProcessed("b"))
-
-      expectMsg("b")
-
-      expectMsg(ShutdownSuccessfully)
-
-    }
-
-    "abandon work when delegatee times out" in new QueueScope {
-      val queueProcessor = initQueue(iteratorQueue(List("a", "b").iterator, WorkSettings(timeout = 288.milliseconds)))
-
-      delegatee.expectMsg(DelegateeMessage("a"))
-
-      delegatee.expectNoMsg(250.milliseconds)
-
-      delegatee.expectMsg(DelegateeMessage("b"))
-      watch(queueProcessor)
-      queueProcessor ! Shutdown
-
-      expectTerminated(queueProcessor)
-    }
-
-    "does not retrieve work without workers" in new QueueScope with Backends with MockitoSugar with Eventually {
-      import org.mockito.Mockito._
-      val iterator = mock[Iterator[String]]
-      val queue = system.actorOf(Queue.ofIterator(iterator, metricsCollector, WorkSettings(), Some(self)))
-
-      expectNoMsg(40.milliseconds)
-      verifyNoMoreInteractions(iterator)
-
-    }
-
-  }
-
   "Queue" should {
 
     "dispatch work on demand on parallel" in new QueueScope {


### PR DESCRIPTION
Fix #151 by two measures 
a) remove the logic auto health checker when worker fails (this prevents from recreating instantly failing workers without speed bound), a more long term approach would probably be #123 and then #152 
b) move the enqueue logic of iterator queue to only in the `RequestWork` received block, so that it only tries to retrieve work when there is a request work received. 

I also moved some tests and improved the integration tests with the ability to send metrics to statsD. 
