### PR TITLE
Latency aware autothrottle fix #149

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -13,7 +13,7 @@ kanaloa {
     workerPool {
 
       # Starting number of workers
-      startingPoolSize = 10
+      startingPoolSize = 30
 
       # Minimum number of workers
       minPoolSize = 1

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -120,8 +120,14 @@ kanaloa {
       downsizeAfterUnderUtilization = 72h
 
       # When optimizing, the autothrottler only considers the sizes adjacent to the
-      # current size. This number indicates how many adjacent sizes to consider.
-      numOfAdjacentSizesToConsiderDuringOptimization = 12
+      # current size. This number indicates how many adjacent sizes, at least, per side to consider .
+      optimizationMinRange = 6
+
+      # When optimizing, the autothrottler only considers the sizes adjacent to the
+      # current size. This number indicates the ratio between the number of adjacent sizes per side to current size.
+      # E.g. 0.3 means that when pool size is at 100, the optimization will look at all pool sizes from 70-130 for
+      # finding an optimal one to move towards to.
+      optimizationRangeRatio = 0.3
 
       # The maximum pool size change during
       # exploration. for example, 5 means that the change will be within +- 5

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -123,11 +123,9 @@ kanaloa {
       # current size. This number indicates how many adjacent sizes to consider.
       numOfAdjacentSizesToConsiderDuringOptimization = 12
 
-      # Duration exploration, the ratio between the largest step size and
-      # current pool size. E.g. if the current pool size is 50, and the
-      # explore-step-size is 0.1, the maximum pool size change during
-      # exploration will be +- 5, this is caped at 4
-      exploreStepSize = 0.1
+      # The maximum pool size change during
+      # exploration. for example, 5 means that the change will be within +- 5
+      maxExploreStepSize = 5
 
       # When downsizing after a long streak of underutilization, the autothrottler
       # will downsize the pool to the highest utiliziation multiplied by a
@@ -155,8 +153,8 @@ kanaloa {
       # ```
       # weightOfLatency * normalizedLatency + (1 - weightOfLatency) * normalizedThroughput
       # ```
-      # E.g. a weightOfLatency = 0.1
-      # means that a 10% improvements on latency has the same weight as 2%
+      # E.g. a weightOfLatency = 0.1 means that
+      # a 10% improvement on latency has the same weight as a 2% improvement of throughput
       weightOfLatency = 0.2
     }
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -147,8 +147,8 @@ kanaloa {
       # Obviously, this number should be between 0 and 1.
       weightOfLatestMetric = 0.2
 
-      # When evaluating performance of a pool size, the weightOfLatency determins
-      # how much weight on latency v.s. throughput. The total score of a sice is
+      # When evaluating performance of a pool size, the weightOfLatency determines
+      # how much weight on latency v.s. throughput. The score of a particular pool size is
       # calculated by
       # ```
       # weightOfLatency * normalizedLatency + (1 - weightOfLatency) * normalizedThroughput

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -78,7 +78,7 @@ kanaloa {
       # Given a weight of 0.3, the metrics
       # representing pool size 5 will be 6 * 0.3 + 10 * 0.7, i.e. 8.8 messages per millis
       # Obviously, this number should be between 0 and 1.
-      weightOfLatestMetric = 0.3
+      weightOfLatestMetric = 0.2
     }
 
     # It automatically adjust the size of work pool (and thus the concurrency)
@@ -109,7 +109,7 @@ kanaloa {
 
       # The probability of ramping down when all workers are busy
       # during exploration.
-      chanceOfScalingDownWhenFull = 0.1
+      chanceOfScalingDownWhenFull = 0.3
 
       # Interval between each pool size adjustment attempt
       # This interval must be at least as long as the update interval
@@ -126,7 +126,7 @@ kanaloa {
       # Duration exploration, the ratio between the largest step size and
       # current pool size. E.g. if the current pool size is 50, and the
       # explore-step-size is 0.1, the maximum pool size change during
-      # exploration will be +- 5
+      # exploration will be +- 5, this is caped at 4
       exploreStepSize = 0.1
 
       # When downsizing after a long streak of underutilization, the autothrottler
@@ -147,7 +147,17 @@ kanaloa {
       # message at pool size 5. Given a weight of 0.3, the metrics
       # representing pool size 5 will be 6 * 0.3 + 10 * 0.7, i.e. 8.8 millis
       # Obviously, this number should be between 0 and 1.
-      weightOfLatestMetric = 0.5
+      weightOfLatestMetric = 0.2
+
+      # When evaluating performance of a pool size, the weightOfLatency determins
+      # how much weight on latency v.s. throughput. The total score of a sice is
+      # calculated by
+      # ```
+      # weightOfLatency * normalizedLatency + (1 - weightOfLatency) * normalizedThroughput
+      # ```
+      # E.g. a weightOfLatency = 0.1
+      # means that a 10% improvements on latency has the same weight as 2%
+      weightOfLatency = 0.2
     }
 
     # Metrics report configuration

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/PerformanceSampler.scala
@@ -172,7 +172,7 @@ private[dispatcher] object PerformanceSampler {
     val minSampleDuration: Duration = sampleInterval * minSampleDurationRatio
   }
 
-  case class QueueStatus(
+  private case class QueueStatus(
     queueLength:    QueueLength,
     workDone:       Int              = 0,
     start:          Time             = Time.now,

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
@@ -6,6 +6,7 @@ import akka.actor._
 import kanaloa.reactive.dispatcher.ApiProtocol.QueryStatus
 import kanaloa.reactive.dispatcher.PerformanceSampler
 import kanaloa.reactive.dispatcher.PerformanceSampler._
+import kanaloa.reactive.dispatcher.Types.Speed
 import kanaloa.reactive.dispatcher.queue.Autothrottler._
 import kanaloa.reactive.dispatcher.queue.QueueProcessor.ScaleTo
 import kanaloa.util.Java8TimeExtensions._
@@ -28,7 +29,7 @@ trait Autothrottler extends Actor with ActorLogging with MessageScheduler {
 
   val random: Random = new Random(23)
   var actionScheduler: Option[Cancellable] = None
-  var perfLog: PerformanceLog = Map.empty
+  var perfLog: PerformanceLogs = Map.empty
 
   override def preStart(): Unit = {
     super.preStart()
@@ -78,10 +79,7 @@ trait Autothrottler extends Actor with ActorLogging with MessageScheduler {
 
   private def fullyUtilized(currentSize: PoolSize): Receive = watchingQueueAndProcessor orElse {
     case s: Sample if s.poolSize > 0 ⇒
-      val toUpdate = perfLog.get(s.poolSize).fold(s.speed.value) { oldSpeed ⇒
-        oldSpeed * (1d - weightOfLatestMetric) + (s.speed.value * weightOfLatestMetric)
-      }
-      perfLog += (s.poolSize → toUpdate)
+      perfLog = updateLogs(perfLog, s, weightOfLatestMetric)
       context become fullyUtilized(s.poolSize)
 
     case PartialUtilization(u) ⇒
@@ -89,7 +87,7 @@ trait Autothrottler extends Actor with ActorLogging with MessageScheduler {
 
     case OptimizeOrExplore ⇒
       val action = {
-        if (random.nextDouble() < explorationRatio)
+        if (random.nextDouble() < explorationRatio || perfLog.size < 2)
           explore(currentSize)
         else
           optimize(currentSize)
@@ -103,35 +101,16 @@ trait Autothrottler extends Actor with ActorLogging with MessageScheduler {
   }
 
   private def optimize(currentSize: PoolSize): ScaleTo = {
-
-    val adjacentPerformances: PerformanceLog = {
-      def adjacency = (size: Int) ⇒ Math.abs(currentSize - size)
-      val sizes = perfLog.keys.toSeq
-      val numOfSizesEachSide = numOfAdjacentSizesToConsiderDuringOptimization / 2
-      val leftBoundary = sizes.filter(_ < currentSize).sortBy(adjacency).take(numOfSizesEachSide).lastOption.getOrElse(currentSize)
-      val rightBoundary = sizes.filter(_ >= currentSize).sortBy(adjacency).take(numOfSizesEachSide).lastOption.getOrElse(currentSize)
-      perfLog.filter { case (size, _) ⇒ size >= leftBoundary && size <= rightBoundary }
-    }
-
-    log.debug("Optimizing based on performance table: " +
-      adjacentPerformances.toList.sortBy(_._2).takeRight(10).reverse.map(p ⇒ s"Sz: ${p._1} spd: ${p._2 * 100} ").mkString(" | "))
-
-    val optimalSize = adjacentPerformances.maxBy(_._2)._1
-
-    val scaleStep = Math.ceil((optimalSize - currentSize).toDouble / 2.0).toInt
-
-    if (scaleStep > 0)
-      log.debug("Optimized to " + (currentSize + scaleStep) + " from " + currentSize)
-
-    ScaleTo(currentSize + scaleStep, Some("optimizing"))
+    val newSize = Autothrottler.optimize(currentSize, perfLog, numOfAdjacentSizesToConsiderDuringOptimization, weightOfLatency)
+    ScaleTo(newSize, Some("optimizing"))
   }
 
   private def explore(currentSize: PoolSize): ScaleTo = {
     val change = Math.max(1, Random.nextInt(Math.ceil(currentSize.toDouble * exploreStepSize).toInt))
-    if (random.nextDouble() < chanceOfScalingDownWhenFull)
-      ScaleTo(currentSize - change, Some("exploring"))
-    else
-      ScaleTo(currentSize + change, Some("exploring"))
+    ScaleTo(
+      currentSize + (if (random.nextDouble() < chanceOfScalingDownWhenFull) -change else change),
+      Some("exploring")
+    )
   }
 
   private implicit def durationToJDuration(d: FiniteDuration): JDuration = JDuration.ofNanos(d.toNanos)
@@ -141,18 +120,75 @@ object Autothrottler {
   case object OptimizeOrExplore
 
   /**
+   *
+   * @param currentSize
+   * @param perfLog
+   * @param numOfAdjacentSizesToConsiderDuringOptimization
+   * @return change to pool
+   */
+  private[queue] def optimize(
+    currentSize:                                    PoolSize,
+    perfLog:                                        PerformanceLogs,
+    numOfAdjacentSizesToConsiderDuringOptimization: Int,
+    weightOfLatency:                                Double
+  ): PoolSize = {
+
+    val adjacentPerformances: PerformanceLogs = {
+      def adjacency = (size: Int) ⇒ Math.abs(currentSize - size)
+      val sizes = perfLog.keys.toSeq
+      val numOfSizesEachSide = numOfAdjacentSizesToConsiderDuringOptimization / 2
+      val leftBoundary = sizes.filter(_ < currentSize).sortBy(adjacency).take(numOfSizesEachSide).lastOption.getOrElse(currentSize)
+      val rightBoundary = sizes.filter(_ >= currentSize).sortBy(adjacency).take(numOfSizesEachSide).lastOption.getOrElse(currentSize)
+      perfLog.filter { case (size, _) ⇒ size >= leftBoundary && size <= rightBoundary }
+    }
+    val currentPerf = perfLog.get(currentSize).getOrElse(adjacentPerformances.head._2)
+    val normalized = adjacentPerformances.map {
+      case (size, that) ⇒
+        val speedImprovement = (that.speed.value - currentPerf.speed.value) / currentPerf.speed.value
+        val latencyImprovement = (for {
+          currentLatency ← currentPerf.processTime
+          thatLatency ← that.processTime
+        } yield (currentLatency - thatLatency).toNanos.toDouble / currentLatency.toNanos.toDouble) getOrElse 0d
+
+        val improvement = (latencyImprovement * weightOfLatency) + (speedImprovement * (1d - weightOfLatency))
+        (size, improvement)
+    }
+    val optimalSize = normalized.maxBy(_._2)._1
+
+    val scaleStep = Math.ceil((optimalSize - currentSize).toDouble / 2.0).toInt
+
+    currentSize + scaleStep
+  }
+
+  private[queue] def updateLogs(logs: PerformanceLogs, sample: Sample, weightOfLatestMetric: Double): PerformanceLogs = {
+    val existingEntry = logs.get(sample.poolSize)
+    val newSpeed = existingEntry.fold(sample.speed) { e ⇒
+      Speed(e.speed.value * (1d - weightOfLatestMetric) + (sample.speed.value * weightOfLatestMetric))
+    }
+    val lastProcessTimeO = existingEntry.flatMap(_.processTime)
+    val newProcessTime = (for {
+      lastPT ← lastProcessTimeO
+      newPT ← sample.avgProcessTime
+    } yield lastPT * (1d - weightOfLatestMetric) + (newPT * weightOfLatestMetric)) orElse sample.avgProcessTime orElse lastProcessTimeO
+
+    logs + (sample.poolSize → PerformanceLogEntry(newSpeed, newProcessTime))
+  }
+
+  /**
    * Mostly for testing purpose
    */
   private[queue] case class AutothrottleStatus(
     partialUtilization:      Option[Int]      = None,
     partialUtilizationStart: Option[Time]     = None,
-    performanceLog:          PerformanceLog   = Map.empty,
+    performanceLog:          PerformanceLogs  = Map.empty,
     poolSize:                Option[PoolSize] = None
   )
 
   type PoolSize = Int
 
-  private[queue]type PerformanceLog = Map[PoolSize, Double]
+  private[queue] case class PerformanceLogEntry(speed: Speed, processTime: Option[Duration] = None)
+
+  private[queue]type PerformanceLogs = Map[PoolSize, PerformanceLogEntry]
 
   case class Default(
     processor:        QueueProcessorRef,

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
@@ -106,7 +106,7 @@ trait Autothrottler extends Actor with ActorLogging with MessageScheduler {
   }
 
   private def explore(currentSize: PoolSize): ScaleTo = {
-    val change = Math.max(1, Random.nextInt(Math.ceil(currentSize.toDouble * exploreStepSize).toInt))
+    val change = Math.max(1, Random.nextInt(maxExploreStepSize))
     ScaleTo(
       currentSize + (if (random.nextDouble() < chanceOfScalingDownWhenFull) -change else change),
       Some("exploring")

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/Autothrottler.scala
@@ -137,8 +137,6 @@ object Autothrottler {
       perfLog.filter { case (size, _) ⇒ size >= leftBoundary && size <= rightBoundary }
     }
 
-    println(adjacentPerformances)
-
     val currentPerf = perfLog.get(currentSize).getOrElse(adjacentPerformances.head._2)
     val normalized = adjacentPerformances.map {
       case (size, that) ⇒

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -55,14 +55,15 @@ package kanaloa.reactive.dispatcher.queue {
    * @param explorationRatio chance of doing a exploration vs an optimization
    */
   case class AutothrottleSettings(
-    chanceOfScalingDownWhenFull:                    Double         = 0.1,
+    chanceOfScalingDownWhenFull:                    Double         = 0.3,
     resizeInterval:                                 FiniteDuration = 5.seconds,
     downsizeAfterUnderUtilization:                  FiniteDuration = 72.hours,
     numOfAdjacentSizesToConsiderDuringOptimization: Int            = 12,
     exploreStepSize:                                Double         = 0.1,
     downsizeRatio:                                  Double         = 0.8,
     explorationRatio:                               Double         = 0.4,
-    weightOfLatestMetric:                           Double         = 0.5
+    weightOfLatestMetric:                           Double         = 0.5,
+    weightOfLatency:                                Double         = 0.2
   )
 
 }

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -50,7 +50,7 @@ package kanaloa.reactive.dispatcher.queue {
    * @param resizeInterval  duration between each pool size adjustment attempt
    * @param downsizeAfterUnderUtilization start to downsize after underutilized for period, should be long enough to include at least one traffic cycle.
    * @param numOfAdjacentSizesToConsiderDuringOptimization during optimization, it only looks at this number of adjacent pool sizes (adjacent to current pool size), to figure out the optimal pool size to move to
-   * @param exploreStepSize during exploration, it takes as big a step as this size. It's a ratio to the current pool size, so if the current size is 10 and the exploreStepSize is 0.2, the exploration will be within a range between 8 and 12
+   * @param maxExploreStepSize during exploration, it takes as big a step as this size. It's a ratio to the current pool size, so if the current size is 10 and the maxExploreStepSize is 0.2, the exploration will be within a range between 8 and 12
    * @param downsizeRatio during downsizing, it will downsize to the largest number of concurrently occupied workers it has seen plus a buffer zone, this downsizeRatio determines the buffer size.
    * @param explorationRatio chance of doing a exploration vs an optimization
    */
@@ -59,7 +59,7 @@ package kanaloa.reactive.dispatcher.queue {
     resizeInterval:                                 FiniteDuration = 5.seconds,
     downsizeAfterUnderUtilization:                  FiniteDuration = 72.hours,
     numOfAdjacentSizesToConsiderDuringOptimization: Int            = 12,
-    exploreStepSize:                                Double         = 0.1,
+    maxExploreStepSize:                             Int            = 4,
     downsizeRatio:                                  Double         = 0.8,
     explorationRatio:                               Double         = 0.4,
     weightOfLatestMetric:                           Double         = 0.5,

--- a/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/queue/package.scala
@@ -21,8 +21,6 @@ package kanaloa.reactive.dispatcher.queue {
 
   /**
    * see reference.conf
-   * @param openDurationBase
-   * @param timeoutCountThreshold
    */
   case class CircuitBreakerSettings(
     openDurationBase:      FiniteDuration = 3.seconds,
@@ -30,9 +28,7 @@ package kanaloa.reactive.dispatcher.queue {
   )
 
   /**
-   *
-   * @param startingPoolSize
-   * @param minPoolSize
+   * see reference.conf
    */
   case class ProcessingWorkerPoolSettings(
     startingPoolSize:         Int            = 5,
@@ -45,25 +41,19 @@ package kanaloa.reactive.dispatcher.queue {
   )
 
   /**
-   *
-   * @param chanceOfScalingDownWhenFull chance of scaling down when the worker pool is fully utilized
-   * @param resizeInterval  duration between each pool size adjustment attempt
-   * @param downsizeAfterUnderUtilization start to downsize after underutilized for period, should be long enough to include at least one traffic cycle.
-   * @param numOfAdjacentSizesToConsiderDuringOptimization during optimization, it only looks at this number of adjacent pool sizes (adjacent to current pool size), to figure out the optimal pool size to move to
-   * @param maxExploreStepSize during exploration, it takes as big a step as this size. It's a ratio to the current pool size, so if the current size is 10 and the maxExploreStepSize is 0.2, the exploration will be within a range between 8 and 12
-   * @param downsizeRatio during downsizing, it will downsize to the largest number of concurrently occupied workers it has seen plus a buffer zone, this downsizeRatio determines the buffer size.
-   * @param explorationRatio chance of doing a exploration vs an optimization
+   * see reference.conf
    */
   case class AutothrottleSettings(
-    chanceOfScalingDownWhenFull:                    Double         = 0.3,
-    resizeInterval:                                 FiniteDuration = 5.seconds,
-    downsizeAfterUnderUtilization:                  FiniteDuration = 72.hours,
-    numOfAdjacentSizesToConsiderDuringOptimization: Int            = 12,
-    maxExploreStepSize:                             Int            = 4,
-    downsizeRatio:                                  Double         = 0.8,
-    explorationRatio:                               Double         = 0.4,
-    weightOfLatestMetric:                           Double         = 0.5,
-    weightOfLatency:                                Double         = 0.2
+    chanceOfScalingDownWhenFull:   Double         = 0.3,
+    resizeInterval:                FiniteDuration = 5.seconds,
+    downsizeAfterUnderUtilization: FiniteDuration = 72.hours,
+    optimizationMinRange:          Int            = 6,
+    optimizationRangeRatio:        Double         = 0.3,
+    maxExploreStepSize:            Int            = 4,
+    downsizeRatio:                 Double         = 0.8,
+    explorationRatio:              Double         = 0.4,
+    weightOfLatestMetric:          Double         = 0.5,
+    weightOfLatency:               Double         = 0.2
   )
 
 }

--- a/core/src/main/scala/kanaloa/util/JavaDurationConverters.scala
+++ b/core/src/main/scala/kanaloa/util/JavaDurationConverters.scala
@@ -1,6 +1,6 @@
-package kanaloa.stress.http
+package kanaloa.util
 
-import java.time.{ Duration => JDuration }
+import java.time.{Duration ⇒ JDuration}
 
 import scala.concurrent.duration.Duration
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
@@ -259,7 +259,7 @@ class AutothrottleWithPushingIntegration extends IntegrationSpec {
 
       val optimalSpeed = optimalSize.toDouble / processTime.toMillis
 
-      val sent = sendLoadsOfMessage(pd, duration = 6.seconds, msgPerMilli = optimalSpeed * 0.9, verbose)
+      val sent = sendLoadsOfMessage(pd, duration = 7.seconds, msgPerMilli = optimalSpeed * 0.9, verbose)
 
       val actualPoolSize = getPoolSize(pd.underlyingActor)
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/IntegrationTests.scala
@@ -40,10 +40,7 @@ trait IntegrationSpec extends WordSpecLike with ShouldMatchers {
       }
 
       kanaloa.default-dispatcher {
-        dispatchHistory {
-          maxHistoryLength = 200ms
-          historySampleRate = 20ms
-        }
+
       }
     """
   ))
@@ -232,7 +229,7 @@ class AutothrottleWithPushingIntegration extends IntegrationSpec {
         "test-pushing",
         backend,
         ConfigFactory.parseString(
-          """
+          s"""
           kanaloa.dispatchers.test-pushing {
             updateInterval = 100ms
             workerPool {
@@ -246,10 +243,12 @@ class AutothrottleWithPushingIntegration extends IntegrationSpec {
             }
             autothrottle {
               chanceOfScalingDownWhenFull = 0.3
-              resizeInterval = 100ms
-              downsizeAfterUnderUtilization = 72h
-
+              resizeInterval = 200ms
+              weightOfLatency = 0.1
+              explorationRatio = 0.5
+              maxExploreStepSize = 1
             }
+            $metricsConfig
           }
         """
         )
@@ -260,7 +259,7 @@ class AutothrottleWithPushingIntegration extends IntegrationSpec {
 
       val optimalSpeed = optimalSize.toDouble / processTime.toMillis
 
-      val sent = sendLoadsOfMessage(pd, duration = 5.seconds, msgPerMilli = optimalSpeed * 0.9, verbose)
+      val sent = sendLoadsOfMessage(pd, duration = 6.seconds, msgPerMilli = optimalSpeed * 0.9, verbose)
 
       val actualPoolSize = getPoolSize(pd.underlyingActor)
 
@@ -390,7 +389,7 @@ class AutothrottleDownSizeWithSparseTrafficIntegration extends IntegrationSpec {
 }
 
 object IntegrationTests {
-  val shutdownTimeout = 30.seconds
+  val shutdownTimeout = 60.seconds
 
   case class Reply(to: ActorRef, delay: Duration, scheduled: LocalDateTime = LocalDateTime.now)
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/PerformanceSamplerSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/PerformanceSamplerSpec.scala
@@ -53,6 +53,23 @@ class PerformanceSamplerSpec extends SpecWithActorSystem with MockitoSugar with 
 
     }
 
+    "collects avgProcess time" in {
+      val (ps, subscriberProbe) = initPerformanceSampler(sampleInterval = 100.milliseconds)
+      ps ! WorkCompleted(1.millisecond)
+      ps ! WorkCompleted(5.millisecond)
+
+      val sample1 = subscriberProbe.expectMsgType[Sample]
+      sample1.avgProcessTime should contain(3.milliseconds)
+
+      ps ! WorkCompleted(5.millisecond)
+      ps ! WorkCompleted(9.millisecond)
+      ps ! WorkCompleted(4.millisecond)
+
+      val sample2 = subscriberProbe.expectMsgType[Sample]
+      sample2.avgProcessTime should contain(6.milliseconds)
+
+    }
+
     "ignore metrics when pool isn't fully occupied" in {
       val (ps, subscriberProbe) = initPerformanceSampler()
       ps ! partialUtilizedStatus

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
@@ -16,7 +16,7 @@ class RegulatorSpec extends SpecWithActorSystem {
     queueLength: Int            = 5,
     duration:    FiniteDuration = 1.second
   ): Sample =
-    Sample(workDone, duration.ago, Time.now, poolSize = 14, queueLength = QueueLength(queueLength))
+    Sample(workDone, duration.ago, Time.now, poolSize = 14, queueLength = QueueLength(queueLength), None)
 
   def status(
     delay:             FiniteDuration = 1.second,

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutothrottlerSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/AutothrottlerSpec.scala
@@ -18,8 +18,8 @@ import scala.concurrent.duration._
 
 class AutothrottleSpec extends SpecWithActorSystem with OptionValues with Eventually {
 
-  def sample(poolSize: PoolSize) =
-    Sample(3, 2.second.ago, 1.second.ago, poolSize, QueueLength(14))
+  def sample(poolSize: PoolSize, avgProcessTime: Option[Duration] = None) =
+    Sample(3, 2.second.ago, 1.second.ago, poolSize, QueueLength(14), avgProcessTime)
 
   "Autothrottle" should {
     "when no history" in new AutothrottleScope {
@@ -127,7 +127,7 @@ class AutothrottleSpec extends SpecWithActorSystem with OptionValues with Eventu
       scaleCmd.numOfWorkers should be < 45
     }
 
-    "ignore further away sample data when optmizing" in new AutothrottleScope {
+    "ignore further away sample data when optimizing" in new AutothrottleScope {
       val subject = autothrottlerRef(alwaysOptimizeSettings)
       mockBusyHistory(
         subject,
@@ -229,7 +229,8 @@ class AutothrottleScope(implicit system: ActorSystem)
           start = distance.seconds.ago,
           end = (distance - 1).seconds.ago,
           poolSize = size,
-          queueLength = QueueLength(14)
+          queueLength = QueueLength(14),
+          None
         )
     }
 

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
@@ -28,6 +28,11 @@ class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backen
     val testWorkerFactory = new TestWorkerFactory()
     val metricsCollector = TestProbe("metrics-collector")
     val qp = TestActorRef[QueueProcessor](QueueProcessor.default(queueProbe.ref, testBackend, poolSettings, metricsCollector.ref, None, testWorkerFactory)(SimpleResultChecker))
+
+    eventually {
+      qp.underlyingActor.workerPool should have size poolSettings.startingPoolSize
+    }
+
     watch(qp)
     try {
       test(qp, queueProbe, metricsCollector, testBackend, testWorkerFactory)
@@ -51,8 +56,7 @@ class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backen
 
   "The QueueProcessor" should {
 
-    "create Workers on startup" in withQueueProcessor() { (qp, queueProbe, metricsCollector, testBackend, workerFactory) ⇒
-      qp.underlyingActor.workerPool should have size 5
+    "create Workers on startup" in withQueueProcessor(ProcessingWorkerPoolSettings(startingPoolSize = 5)) { (qp, queueProbe, metricsCollector, testBackend, workerFactory) ⇒
       testBackend.timesInvoked shouldBe 5
     }
 
@@ -66,6 +70,30 @@ class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backen
         qp.underlyingActor.workerPool should have size 10
         testBackend.timesInvoked shouldBe 10
       }
+    }
+
+    "does not scale workers when there is already workers creation in flight" in new Backends {
+      import system.dispatcher
+      val promise = Promise[ActorRef]
+      val backend = promiseBackend(promise)
+      val metricsCollectorProbe = TestProbe()
+      val qp = TestActorRef[QueueProcessor](QueueProcessor.default(
+        TestProbe().ref,
+        backend,
+        ProcessingWorkerPoolSettings(startingPoolSize = 1),
+        metricsCollectorProbe.ref
+      )(
+          SimpleResultChecker
+        ))
+
+      qp ! ScaleTo(10) //this should be ignored
+
+      promise.success(TestProbe().ref)
+
+      metricsCollectorProbe.expectMsg(PoolSize(0))
+      metricsCollectorProbe.expectMsg(PoolSize(1))
+      metricsCollectorProbe.expectNoMsg(30.milliseconds)
+
     }
 
     "scale workers down" in withQueueProcessor() { (qp, queueProbe, metricsCollector, testBackend, workerFactory) ⇒

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/queue/QueueProcessorSpec.scala
@@ -13,13 +13,11 @@ import kanaloa.reactive.dispatcher.queue.QueueProcessor.{ScaleTo, Shutdown, Shut
 import kanaloa.reactive.dispatcher._
 import kanaloa.reactive.dispatcher.queue.TestUtils.{MessageProcessed, DelegateeMessage}
 import org.scalatest.concurrent.Eventually
-import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
 import scala.collection.mutable.{Map ⇒ MMap}
 import scala.concurrent.{Promise, Future}
 import scala.concurrent.duration._
 
-class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backends with MockitoSugar {
+class QueueProcessorSpec extends SpecWithActorSystem with Eventually with Backends {
 
   type QueueTest = (TestActorRef[QueueProcessor], TestProbe, TestProbe, TestBackend, TestWorkerFactory) ⇒ Any
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,8 +27,8 @@ object Dependencies {
   )
 
   val gatling = Seq(
-    "io.gatling.highcharts" % "gatling-charts-highcharts" % "2.2.1" % Test,
-    "io.gatling"            % "gatling-test-framework"    % "2.2.1" % Test
+    "io.gatling.highcharts" % "gatling-charts-highcharts" % "2.2.2" % Test,
+    "io.gatling"            % "gatling-test-framework"    % "2.2.2" % Test
   )
 
   val (test, integration) = {

--- a/stress/backend/src/main/resources/backend.conf
+++ b/stress/backend/src/main/resources/backend.conf
@@ -1,0 +1,4 @@
+optimal-concurrency  = 10  //optimal concurrent requests the backend can handle
+optimal-throughput =  100    //the opitmal throughput (msg / second) the backend can handle
+buffer-size = 5000
+overload-punish-factor = 0.1  //between 1 and 0, one gives the maximum punishment while 0 gives none

--- a/stress/backend/src/main/resources/backend.conf
+++ b/stress/backend/src/main/resources/backend.conf
@@ -1,4 +1,4 @@
 optimal-concurrency  = 10  //optimal concurrent requests the backend can handle
 optimal-throughput =  100    //the opitmal throughput (msg / second) the backend can handle
 buffer-size = 5000
-overload-punish-factor = 0.1  //between 1 and 0, one gives the maximum punishment while 0 gives none
+overload-punish-factor = 0  //between 1 and 0, one gives the maximum punishment while 0 gives none

--- a/stress/backend/src/main/resources/backend.conf
+++ b/stress/backend/src/main/resources/backend.conf
@@ -2,3 +2,28 @@ optimal-concurrency  = 10  //optimal concurrent requests the backend can handle
 optimal-throughput =  100    //the opitmal throughput (msg / second) the backend can handle
 buffer-size = 5000
 overload-punish-factor = 0  //between 1 and 0, one gives the maximum punishment while 0 gives none
+
+akka {
+  actor {
+    provider = "akka.cluster.ClusterActorRefProvider"
+    warn-about-java-serializer-usage = off
+  }
+
+  remote {
+    log-remote-lifecycle-events = on
+    netty.tcp {
+      hostname = "127.0.0.1"
+      port = 0
+    }
+  }
+
+  cluster {
+    seed-nodes = [
+      "akka.tcp://kanaloa-stress@127.0.0.1:2551"]
+    roles = [ backend ]
+    metrics.enabled = off
+
+  }
+
+  loglevel= "INFO"
+}

--- a/stress/backend/src/main/scala/kanaloa/stress/backend/BackendApp.scala
+++ b/stress/backend/src/main/scala/kanaloa/stress/backend/BackendApp.scala
@@ -1,8 +1,10 @@
 package kanaloa.stress.backend
 
 import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
 
 object BackendApp extends App {
-  val system = ActorSystem()
+  val system = ActorSystem("kanaloa-stress", ConfigFactory.load("backend.conf"))
   system.actorOf(MockBackend.props, "backend")
+
 }

--- a/stress/backend/src/main/scala/kanaloa/stress/backend/BackendApp.scala
+++ b/stress/backend/src/main/scala/kanaloa/stress/backend/BackendApp.scala
@@ -1,0 +1,8 @@
+package kanaloa.stress.backend
+
+import akka.actor.ActorSystem
+
+object BackendApp extends App {
+  val system = ActorSystem()
+  system.actorOf(MockBackend.props, "backend")
+}

--- a/stress/backend/src/main/scala/kanaloa/stress/backend/MockBackend.scala
+++ b/stress/backend/src/main/scala/kanaloa/stress/backend/MockBackend.scala
@@ -4,10 +4,21 @@ import akka.actor.Props
 import akka.contrib.throttle.TimerBasedThrottler
 import akka.contrib.throttle.Throttler._
 import akka.actor._
+import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 import scala.util.Random
 
 object MockBackend {
+
+  lazy val props = {
+    val cfg = ConfigFactory.load("backend.conf")
+    Props(new BackendRouter(
+      cfg.getInt("optimal-concurrency"),
+      cfg.getInt("optimal-throughput"),
+      cfg.getInt("buffer-size"),
+      Some(cfg.getDouble("overload-punish-factor"))
+    ))
+  }
 
   /**
    *

--- a/stress/frontend/src/main/resources/frontend.conf
+++ b/stress/frontend/src/main/resources/frontend.conf
@@ -33,3 +33,41 @@ kanaloa {
   }
 
 }
+
+
+akka {
+  actor {
+    provider = "akka.cluster.ClusterActorRefProvider"
+    warn-about-java-serializer-usage = off
+
+    deployment {
+      /backendRouter = {
+        # Router type provided by metrics extension.
+        router = round-robin-group
+        nr-of-instances = 100
+        routees.paths = ["/user/backend"]
+        cluster {
+          enabled = on
+          use-role = backend
+          allow-local-routees = off
+        }
+      }
+    }
+  }
+  remote {
+    log-remote-lifecycle-events = on
+    netty.tcp {
+      hostname = "127.0.0.1"
+      port = 2551
+    }
+  }
+
+  cluster {
+    seed-nodes = [
+      "akka.tcp://kanaloa-stress@127.0.0.1:2551"]
+    roles = [ frontend ]
+    metrics.enabled = off
+  }
+
+  loglevel= "INFO"
+}

--- a/stress/frontend/src/main/resources/frontend.conf
+++ b/stress/frontend/src/main/resources/frontend.conf
@@ -9,7 +9,7 @@ kanaloa {
     updateInterval = 200ms
 
     workerPool {
-      startingPoolSize = 20
+      startingPoolSize = 50
     }
 
     autothrottle {

--- a/stress/frontend/src/main/resources/frontend.conf
+++ b/stress/frontend/src/main/resources/frontend.conf
@@ -1,8 +1,5 @@
-optimal-concurrency  = 10  //optimal concurrent requests the backend can handle
-optimal-throughput =  100    //the opitmal throughput (msg / second) the backend can handle
-buffer-size = 5000
+
 frontend-timeout = 30s
-overload-punish-factor = 0.1  //between 1 and 0, one gives the maximum punishment while 0 gives none
 
 kanaloa {
 

--- a/stress/frontend/src/main/resources/stressTestInfra.conf
+++ b/stress/frontend/src/main/resources/stressTestInfra.conf
@@ -1,5 +1,3 @@
-use-kanaloa = true  //run test with kanaloa?
-
 optimal-concurrency  = 20  //optimal concurrent requests the backend can handle
 optimal-throughput =  400    //the opitmal throughput (msg / second) the backend can handle
 base-latency = 50ms

--- a/stress/frontend/src/main/resources/stressTestInfra.conf
+++ b/stress/frontend/src/main/resources/stressTestInfra.conf
@@ -1,8 +1,8 @@
-optimal-concurrency  = 20  //optimal concurrent requests the backend can handle
-optimal-throughput =  400    //the opitmal throughput (msg / second) the backend can handle
-base-latency = 50ms
-buffer-size = 8000
-timeout = 3s
+optimal-concurrency  = 10  //optimal concurrent requests the backend can handle
+optimal-throughput =  100    //the opitmal throughput (msg / second) the backend can handle
+buffer-size = 5000
+frontend-timeout = 30s
+overload-punish-factor = 0  //between 1 and 0, one gives the maximum punishment while 0 gives none
 
 kanaloa {
 
@@ -12,7 +12,7 @@ kanaloa {
     updateInterval = 200ms
 
     workerPool {
-      startingPoolSize = 8
+      startingPoolSize = 20
     }
 
     autothrottle {
@@ -21,7 +21,7 @@ kanaloa {
     }
 
     backPressure {
-      referenceDelay = ${timeout}
+      referenceDelay = 1s
       durationOfBurstAllowed = 5s
     }
 

--- a/stress/frontend/src/main/resources/stressTestInfra.conf
+++ b/stress/frontend/src/main/resources/stressTestInfra.conf
@@ -2,7 +2,7 @@ optimal-concurrency  = 10  //optimal concurrent requests the backend can handle
 optimal-throughput =  100    //the opitmal throughput (msg / second) the backend can handle
 buffer-size = 5000
 frontend-timeout = 30s
-overload-punish-factor = 0  //between 1 and 0, one gives the maximum punishment while 0 gives none
+overload-punish-factor = 0.1  //between 1 and 0, one gives the maximum punishment while 0 gives none
 
 kanaloa {
 

--- a/stress/frontend/src/main/resources/stressTestInfra.conf
+++ b/stress/frontend/src/main/resources/stressTestInfra.conf
@@ -1,7 +1,7 @@
 optimal-concurrency  = 20  //optimal concurrent requests the backend can handle
 optimal-throughput =  400    //the opitmal throughput (msg / second) the backend can handle
 base-latency = 50ms
-buffer-size = 5000
+buffer-size = 8000
 timeout = 3s
 
 kanaloa {
@@ -22,7 +22,7 @@ kanaloa {
 
     backPressure {
       referenceDelay = ${timeout}
-      durationOfBurstAllowed = 30s
+      durationOfBurstAllowed = 5s
     }
 
     metrics {

--- a/stress/frontend/src/main/scala/kanaloa/stress/http/JavaDurationConverters.scala
+++ b/stress/frontend/src/main/scala/kanaloa/stress/http/JavaDurationConverters.scala
@@ -1,6 +1,6 @@
 package kanaloa.stress.http
 
-import java.time.{Duration => JDuration}
+import java.time.{ Duration => JDuration }
 
 import scala.concurrent.duration.Duration
 

--- a/stress/frontend/src/main/scala/kanaloa/stress/http/StressHttpFrontend.scala
+++ b/stress/frontend/src/main/scala/kanaloa/stress/http/StressHttpFrontend.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 import JavaDurationConverters._
 
 object StressHttpFrontend extends App {
-  val cfg = ConfigFactory.load("stressTestInfra.conf")
+  val cfg = ConfigFactory.load("frontend.conf")
 
   implicit val system = ActorSystem("Stress-Tests", cfg.resolve())
   implicit val materializer = ActorMaterializer()
@@ -25,15 +25,7 @@ object StressHttpFrontend extends App {
 
   case class Failed(msg: String)
 
-  val backend = system.actorOf(
-    Props(new MockBackend.BackendRouter(
-      cfg.getInt("optimal-concurrency"),
-      cfg.getInt("optimal-throughput"),
-      cfg.getInt("buffer-size"),
-      Some(cfg.getDouble("overload-punish-factor"))
-    )),
-    name = "backend"
-  )
+  val backend = system.actorOf(MockBackend.props, name = "backend")
 
   lazy val dispatcher =
     system.actorOf(PushingDispatcher.props(

--- a/stress/frontend/src/main/scala/kanaloa/stress/http/StressHttpFrontend.scala
+++ b/stress/frontend/src/main/scala/kanaloa/stress/http/StressHttpFrontend.scala
@@ -9,12 +9,12 @@ import akka.pattern.{ AskTimeoutException, ask }
 import akka.util.Timeout
 import kanaloa.reactive.dispatcher.ApiProtocol.{ WorkRejected, WorkTimedOut, WorkFailed }
 import kanaloa.stress.backend.MockBackend
+import kanaloa.util.JavaDurationConverters._
 import scala.util.{ Failure, Success }
 import scala.io.StdIn._
 import com.typesafe.config.ConfigFactory
 import kanaloa.reactive.dispatcher.PushingDispatcher
 import scala.concurrent.duration._
-import JavaDurationConverters._
 
 object StressHttpFrontend extends App {
   val cfg = ConfigFactory.load("frontend.conf")

--- a/stress/frontend/src/main/scala/kanaloa/stress/http/StressHttpFrontend.scala
+++ b/stress/frontend/src/main/scala/kanaloa/stress/http/StressHttpFrontend.scala
@@ -31,7 +31,7 @@ object StressHttpFrontend extends App {
 
   lazy val dispatcher =
     system.actorOf(PushingDispatcher.props(
-      name = "my-service1",
+      name = "with-local-backend",
       localBackend,
       cfg
     ) {

--- a/stress/gatling/src/test/resources/gatling.conf
+++ b/stress/gatling/src/test/resources/gatling.conf
@@ -52,7 +52,7 @@ gatling {
     #accuracy = 10           # Accuracy, in milliseconds, of the report's stats
     indicators {
       lowerBound = 50      # Lower bound for the requests' response time to track in the reports and the console summary
-      higherBound = 2000    # Higher bound for the requests' response time to track in the reports and the console summary
+      higherBound = 60000    # Higher bound for the requests' response time to track in the reports and the console summary
       #percentile1 = 50      # Value for the 1st percentile to track in the reports, the console summary and GraphiteDataWriter
       #percentile2 = 75      # Value for the 2nd percentile to track in the reports, the console summary and GraphiteDataWriter
       #percentile3 = 95      # Value for the 3rd percentile to track in the reports, the console summary and GraphiteDataWriter

--- a/stress/gatling/src/test/resources/gatling.conf
+++ b/stress/gatling/src/test/resources/gatling.conf
@@ -48,8 +48,8 @@ gatling {
   }
   charting {
     #noReports = false       # When set to true, don't generate HTML reports
-    maxPlotPerSeries = 100000 # Number of points per graph in Gatling reports
-    #accuracy = 10           # Accuracy, in milliseconds, of the report's stats
+    maxPlotPerSeries = 5000000 # Number of points per graph in Gatling reports
+    accuracy = 100           # Accuracy, in milliseconds, of the report's stats
     indicators {
       lowerBound = 50      # Lower bound for the requests' response time to track in the reports and the console summary
       higherBound = 60000    # Higher bound for the requests' response time to track in the reports and the console summary

--- a/stress/gatling/src/test/resources/logback.xml
+++ b/stress/gatling/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
     <!-- Uncomment for logging ALL HTTP request and responses -->
     <!--  <logger name="io.gatling.http.ahc.AsyncHandlerActor" level="TRACE" /> -->
     <!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
-    <logger name="io.gatling.http.ahc" level="DEBUG" />
+    <logger name="io.gatling.http.ahc" level="WARN" />
 
     <root level="WARN">
         <appender-ref ref="CONSOLE" />

--- a/stress/gatling/src/test/resources/logback.xml
+++ b/stress/gatling/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
     <!-- Uncomment for logging ALL HTTP request and responses -->
     <!--  <logger name="io.gatling.http.ahc.AsyncHandlerActor" level="TRACE" /> -->
     <!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
-    <logger name="io.gatling.http.ahc" level="WARN" />
+    <logger name="io.gatling.http.ahc" level="ERROR" />
 
     <root level="WARN">
         <appender-ref ref="CONSOLE" />

--- a/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
+++ b/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
@@ -30,12 +30,10 @@ abstract class OverflowSimulation(path: String) extends Simulation {
   }
 
   setUp(scn.inject(
-    rampUsers(850) over (3 minutes) //mainly by throttle below
+    rampUsers(500) over (5 minutes) //mainly by throttle below
   )).throttle(
-    reachRps(100) in (1.minutes),
-    holdFor(1.minutes),
-    reachRps(400) in (3.minutes),
-    holdFor(1.minute)
+    reachRps(200) in (5.minutes),
+    holdFor(3.minute)
   )
     .protocols(httpConf)
     .assertions(global.responseTime.percentile3.lessThan(5000)) //95% less than 5s

--- a/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
+++ b/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 /**
- * Simulation against a local actor with kanaloa in front of it. 
+ * Simulation against a local actor with kanaloa in front of it.
  */
 class KanaloaLocalSimulation extends OverflowSimulation("kanaloa")
 
@@ -37,14 +37,17 @@ abstract class OverflowSimulation(path: String) extends Simulation {
     }
   }
 
+  val duration = 30.minutes
+  val rampUp = 1.minutes
+
   setUp(scn.inject(
     rampUsers(2000) over (5 minutes) //mainly by throttle below
   )).throttle(
-    reachRps(200) in (1.minutes),
-    holdFor(19.minute)
+    reachRps(200) in rampUp,
+    holdFor(duration)
   )
     .protocols(httpConf)
-    .maxDuration(19.minutes)
+    .maxDuration(duration + rampUp)
     .assertions(global.responseTime.percentile3.lessThan(5000)) //95% less than 5s
 
 }

--- a/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
+++ b/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
@@ -30,7 +30,7 @@ abstract class OverflowSimulation(path: String) extends Simulation {
   }
 
   setUp(scn.inject(
-    rampUsers(500) over (5 minutes) //mainly by throttle below
+    rampUsers(2000) over (5 minutes) //mainly by throttle below
   )).throttle(
     reachRps(200) in (5.minutes),
     holdFor(3.minute)

--- a/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
+++ b/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
@@ -32,11 +32,11 @@ abstract class OverflowSimulation(path: String) extends Simulation {
   setUp(scn.inject(
     rampUsers(2000) over (5 minutes) //mainly by throttle below
   )).throttle(
-    reachRps(200) in (2.minutes),
-    holdFor(5.minute)
+    reachRps(200) in (1.minutes),
+    holdFor(19.minute)
   )
     .protocols(httpConf)
-    .maxDuration(10.minutes)
+    .maxDuration(19.minutes)
     .assertions(global.responseTime.percentile3.lessThan(5000)) //95% less than 5s
 
 }

--- a/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
+++ b/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
@@ -32,10 +32,11 @@ abstract class OverflowSimulation(path: String) extends Simulation {
   setUp(scn.inject(
     rampUsers(2000) over (5 minutes) //mainly by throttle below
   )).throttle(
-    reachRps(200) in (5.minutes),
-    holdFor(3.minute)
+    reachRps(200) in (2.minutes),
+    holdFor(5.minute)
   )
     .protocols(httpConf)
+    .maxDuration(10.minutes)
     .assertions(global.responseTime.percentile3.lessThan(5000)) //95% less than 5s
 
 }

--- a/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
+++ b/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
@@ -6,12 +6,20 @@ import io.gatling.http.Predef._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class KanaloaSimulation extends OverflowSimulation("kanaloa")
+/**
+ * Simulation against a local actor with kanaloa in front of it. 
+ */
+class KanaloaLocalSimulation extends OverflowSimulation("kanaloa")
 
 /**
  * Simulation against plain backend without kanaloa
  */
 class StraightSimulation extends OverflowSimulation("straight")
+
+/**
+ * Simulation against a round robin cluster router without kanaloa
+ */
+class RoundRobinSimulation extends OverflowSimulation("round_robin")
 
 abstract class OverflowSimulation(path: String) extends Simulation {
 

--- a/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
+++ b/stress/gatling/src/test/scala/kanaloa/stress/KanaloaSimulation.scala
@@ -1,14 +1,23 @@
+package kanaloa.stress
+
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class KanaloaSimulation extends Simulation {
-  val Url = "http://localhost:8081/kanaloa-test-1"
+class KanaloaSimulation extends OverflowSimulation("kanaloa")
 
-  val httpConf = http
-    .disableCaching
+/**
+ * Simulation against plain backend without kanaloa
+ */
+class StraightSimulation extends OverflowSimulation("straight")
+
+abstract class OverflowSimulation(path: String) extends Simulation {
+
+  val Url = s"http://localhost:8081/$path/test-1"
+
+  val httpConf = http.disableCaching
 
   val scn = scenario("stress-test").forever {
     group("kanaloa") {
@@ -30,4 +39,5 @@ class KanaloaSimulation extends Simulation {
   )
     .protocols(httpConf)
     .assertions(global.responseTime.percentile3.lessThan(5000)) //95% less than 5s
+
 }


### PR DESCRIPTION
This PR also included some improvement on stress tests (part of which are for testing this fix, part of which (e.g. cluster round robin test) are for future testing)
The main fix is to consider latency during autothrottling optimization. A weightOfLatency setting is added. 
When evaluating performance of a pool size, the weightOfLatency determines
how much weight on latency v.s. throughput. The score of a particular pool size is
calculated by

``` scala
weightOfLatency * normalizedLatency + (1 - weightOfLatency) * normalizedThroughput
```

E.g. a weightOfLatency = 0.1 means that a 10% improvement on latency has the same weight as a 2% improvement of throughput. 

The second change is to fix the maximum exploration step size. Before this change the exploration step size (random pool size change during exploration) is based on a ratio of the poolsize, e.g. a 0.1 ratio will mean that during exploration of a Pool size of 100,  it could change up to +- 10. During test it made the pool size very unstable at poolsize larger than 100. It means the system will explore to unknown territorial too fast. So with this change I capped the exploration maximum step size to be an integer setting, e.g. a 4 means that during exploration the pool size can be changed up to  +- 4. 

The third change is to make optimization range a ratio rather than fixed number, this way when it's in larger pool size it gets to consider more pool sizes than a relatively small range 
