### PR TITLE
a dedicated default config for pulling dispatchers fixes #159

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 kanaloa {
 
   #Default settings for all dispatcher
-  default-dispatcher {
+  default-dispatchers {
     workTimeout = 1m
 
     # When displaying messages in logs, this is the length to truncate at.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 kanaloa {
 
-  #Default settings for all dispatcher
-  default-dispatchers {
+  #Default settings for all dispatchers
+  default-dispatcher {
     workTimeout = 1m
 
     # When displaying messages in logs, this is the length to truncate at.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 kanaloa {
 
-  #Default settings
+  #Default settings for all dispatcher
   default-dispatcher {
     workTimeout = 1m
 
@@ -11,7 +11,7 @@ kanaloa {
     updateInterval = 1s
 
     # When backend fails the work, the dispatcher can retry it for this many times.
-    workRetry   = 0
+    workRetry = 0
 
     workerPool {
 
@@ -31,7 +31,7 @@ kanaloa {
       logRouteeRetrievalError = true
 
       # whether or not to shutdown the whole dispatcher when all workers died
-      shutdownOnAllWorkerDeath = true
+      shutdownOnAllWorkerDeath = false
 
       # default timeout for shutingdown
       defaultShutdownTimeout = 30s
@@ -182,6 +182,29 @@ kanaloa {
     }
 
   }
+
+  #Default settings for pulling dispatchers
+  default-pulling-dispatcher {
+    workerPool {
+      shutdownOnAllWorkerDeath = true
+    }
+
+    # for pulling timeout might mean work lost, so it should be more careful.
+    circuitBreaker {
+      openDurationBase = 30s
+      timeoutCountThreshold = 1
+    }
+
+    backPressure {
+      enabled = off
+    }
+
+    autothrottle {
+      downsizeAfterUnderUtilization = 30s
+    }
+  }
+
+
 
   # Your dispatchers config goes here
   dispatchers {

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
@@ -263,7 +263,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
       reporter shouldBe empty
     }
 
-    "use specifi default settings" in {
+    "use a specific default settings" in {
       val (settings, _) = Dispatcher.readConfig("example", ConfigFactory.empty, Some("default-pulling-dispatcher"))
       settings.workerPool.shutdownOnAllWorkerDeath shouldBe true
       settings.autothrottle shouldBe defined

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/DispatcherSpec.scala
@@ -259,7 +259,14 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
       val (settings, reporter) = Dispatcher.readConfig("example", ConfigFactory.empty)
       settings.workRetry === 0
       settings.autothrottle shouldBe defined
+      settings.workerPool.shutdownOnAllWorkerDeath shouldBe false
       reporter shouldBe empty
+    }
+
+    "use specifi default settings" in {
+      val (settings, _) = Dispatcher.readConfig("example", ConfigFactory.empty, Some("default-pulling-dispatcher"))
+      settings.workerPool.shutdownOnAllWorkerDeath shouldBe true
+      settings.autothrottle shouldBe defined
     }
 
     "use default-dispatcher settings when dispatcher name is missing in the dispatchers section" in {


### PR DESCRIPTION
PullingDispatcher is quite different from the pushingDispatcher and thus justified to have a dedicated default settings. This also makes shutdownOnAllWorkerDeath default to off. The rationale is stated in the issue #159
