### PR TITLE
fix the incorrect calculation of expected wait time when partialUtilized fix #162

### DIFF
--- a/core/src/main/scala/kanaloa/reactive/dispatcher/Regulator.scala
+++ b/core/src/main/scala/kanaloa/reactive/dispatcher/Regulator.scala
@@ -69,7 +69,7 @@ class Regulator(settings: Settings, metricsCollector: ActorRef, regulatee: Actor
           droppingRate = DroppingRate(0),
           burstDurationLeft = settings.durationOfBurstAllowed,
           recordedAt = Time.now,
-          delay = estimateDelay(QueueLength(1), status.averageSpeed).getOrElse(Duration.Zero)
+          delay = Duration.Zero
         )
       ) //reset to baseline when seeing a PartialUtilization
     case _: Report ⇒ //ignore other performance report

--- a/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
+++ b/core/src/test/scala/kanaloa/reactive/dispatcher/RegulatorSpec.scala
@@ -92,7 +92,7 @@ class RegulatorSpec extends SpecWithActorSystem {
 
       regulator ! PartialUtilization(0)
 
-      metricsCollector.expectMsgType[Metric.WorkQueueExpectedWaitTime].duration.toMillis shouldBe 333
+      metricsCollector.expectMsgType[Metric.WorkQueueExpectedWaitTime].duration.toMillis shouldBe 0
       metricsCollector.expectMsgType[Metric.DropRate].value shouldBe 0d
       metricsCollector.expectMsgType[Metric.BurstMode].inBurst shouldBe false
     }


### PR DESCRIPTION
The original calculation try to use the average dequeue speed with queue length 1 to estimate the dequeue wait time, but actually when there are idle workers the work should be immediately picked up. 
