### PR TITLE
moving metrics collector in house, making statsDclient an independent…

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ kanaloa {
   default-dispatcher {
     metrics {
       enabled = on
-      statsd {
+      statsD {
         host = "localhost" #host of your statsD server
         port = 8125
       }
@@ -142,7 +142,7 @@ kanaloa {
     }
     example2 {
       metrics {
-        statsd {
+        statsD {
           eventSampleRate = 0.01
         }
       }

--- a/cluster/src/multi-jvm/scala/kanaloa.reactive.dispatcher/ClusterAwareBackendSpec.scala
+++ b/cluster/src/multi-jvm/scala/kanaloa.reactive.dispatcher/ClusterAwareBackendSpec.scala
@@ -10,6 +10,7 @@ import akka.testkit._
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import kanaloa.dispatcher.ClusterAwareBackendSpec._
+import kanaloa.dispatcher.metrics.StatsDClient
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -47,7 +48,7 @@ case class EchoMessage(i: Int)
 
 class ClusterAwareBackendSpec extends  MultiNodeSpec(ClusterAwareBackendSpec) with ClusterSpec with ImplicitSender {
   import ClusterAwareBackendSpec._
-
+  implicit val noStatsD: Option[StatsDClient] = None
 
   "A ClusterAwareBackend" must {
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -170,12 +170,10 @@ kanaloa {
     # Metrics report configuration
     metrics {
       enabled = off
-      #  statsd {
-      #     host = "localhost"
+      #  use statsD for this metrics, also need to config statsD {host and port } down below
+      #  statsD {
       #     namespace = "kanaloa"
-      #
       #     #Everything below is optional
-      #     port = 8125
       #     eventSampleRate = 0.25
       #     statusSampleRate = 1
       #  }
@@ -203,6 +201,22 @@ kanaloa {
       downsizeAfterUnderUtilization = 30s
     }
   }
+
+  # If you need statsD reporting
+  # statsD {
+  #   host = "localhost"
+  #   port = 8125
+  #
+  #   # If true, multiple stats will be sent in a single UDP packet
+  #   multiMetrics = true
+  #
+  #   #If multiMetrics is true, this is the max buffer size before sending the UDP packet
+  #   packetBufferSize = 1024
+  #
+  #   # Default sample rate to use for metrics, if unspecified
+  #   defaultSampleRate = 1.0
+  #
+  # }
 
 
 

--- a/core/src/main/scala/kanaloa/dispatcher/metrics/MetricsCollector.scala
+++ b/core/src/main/scala/kanaloa/dispatcher/metrics/MetricsCollector.scala
@@ -33,10 +33,4 @@ private[dispatcher] object MetricsCollector {
     reporter: Option[Reporter],
     settings: PerformanceSamplerSettings = PerformanceSamplerSettings()
   ): Props = Props(new MetricsCollectorImpl(reporter, settings))
-
-  def apply(
-    reporter: Option[Reporter],
-    settings: PerformanceSamplerSettings = PerformanceSamplerSettings()
-  )(implicit system: ActorSystem): ActorRef = system.actorOf(props(reporter, settings))
-
 }

--- a/core/src/main/scala/kanaloa/dispatcher/metrics/MetricsReporterSettings.scala
+++ b/core/src/main/scala/kanaloa/dispatcher/metrics/MetricsReporterSettings.scala
@@ -3,9 +3,7 @@ package kanaloa.dispatcher.metrics
 sealed trait MetricsReporterSettings
 
 case class StatsDMetricsReporterSettings(
-  host:             String,
   namespace:        String = "kanaloa-dispatchers",
-  port:             Int    = 8125,
   eventSampleRate:  Double = 0.25,
   statusSampleRate: Double = 1
 ) extends MetricsReporterSettings

--- a/core/src/main/scala/kanaloa/dispatcher/metrics/Reporter.scala
+++ b/core/src/main/scala/kanaloa/dispatcher/metrics/Reporter.scala
@@ -8,13 +8,18 @@ trait Reporter {
 }
 
 object Reporter {
-  /** If statsd config exists, create StatsDReporter, otherwise None */
-  def fromConfig(dispatcherName: String, config: Config)(implicit system: ActorSystem): Option[Reporter] = {
+  case object StatsDClientNotProvidedException extends Exception
+
+  /** If statsD config exists, create StatsDReporter, otherwise None */
+  private[dispatcher] def fromConfig(
+    dispatcherName: String,
+    config:         Config,
+    statsDClient:   Option[StatsDClient]
+  ): Option[Reporter] = {
     import net.ceedubs.ficus.Ficus._
     import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 
-    val defaultSettings = config.as[Option[StatsDMetricsReporterSettings]]("metrics.statsd").filter(_ ⇒ config.getOrElse("metrics.enabled", true))
-
-    defaultSettings.map(StatsDReporter(dispatcherName, _))
+    val defaultSettings = config.as[Option[StatsDMetricsReporterSettings]]("metrics.statsD").filter(_ ⇒ config.getOrElse("metrics.enabled", true))
+    defaultSettings.map(StatsDReporter(dispatcherName, _, statsDClient.getOrElse(throw StatsDClientNotProvidedException)))
   }
 }

--- a/core/src/main/scala/kanaloa/dispatcher/queue/Queue.scala
+++ b/core/src/main/scala/kanaloa/dispatcher/queue/Queue.scala
@@ -178,7 +178,12 @@ object QueueOfIterator {
     metricsCollector:    ActorRef,
     sendResultsTo:       Option[ActorRef] = None
   ): Props =
-    Props(new QueueOfIterator(iterator, defaultWorkSettings, metricsCollector, sendResultsTo)).withDeploy(Deploy.local)
+    Props(new QueueOfIterator(
+      iterator,
+      defaultWorkSettings,
+      metricsCollector,
+      sendResultsTo
+    )).withDeploy(Deploy.local)
 
   private case object EnqueueMore
 

--- a/core/src/test/scala/kanaloa/dispatcher/MockReporter.scala
+++ b/core/src/test/scala/kanaloa/dispatcher/MockReporter.scala
@@ -1,0 +1,11 @@
+package kanaloa.dispatcher
+
+import kanaloa.dispatcher.metrics.{Metric, Reporter}
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class MockReporter extends Reporter {
+  private val metrics = new ConcurrentLinkedQueue[Metric]()
+  def reported: List[Metric] = metrics.toArray(new Array[Metric](metrics.size())).toList
+  override def report(metric: Metric): Unit =
+    metrics.add(metric)
+}

--- a/core/src/test/scala/kanaloa/dispatcher/queue/QueueSpec.scala
+++ b/core/src/test/scala/kanaloa/dispatcher/queue/QueueSpec.scala
@@ -178,7 +178,7 @@ class QueueMetricsSpec extends SpecWithActorSystem with Eventually {
 }
 
 class QueueScope(implicit system: ActorSystem) extends ScopeWithQueue {
-  val metricsCollector: ActorRef = MetricsCollector(None) // To be overridden
+  val metricsCollector: ActorRef = system.actorOf(MetricsCollector.props(None)) // To be overridden
 
   def initQueue(queue: ActorRef, numberOfWorkers: Int = 1, minPoolSize: Int = 1): QueueProcessorRef = {
     val processorProps: Props = defaultProcessorProps(queue, ProcessingWorkerPoolSettings(startingPoolSize = numberOfWorkers, minPoolSize = minPoolSize), metricsCollector)
@@ -207,9 +207,9 @@ class MetricCollectorScope(implicit system: ActorSystem) extends QueueScope {
   @volatile
   var receivedMetrics: List[Metric] = Nil
 
-  override val metricsCollector: ActorRef = MetricsCollector(Some(new Reporter {
+  override val metricsCollector: ActorRef = system.actorOf(MetricsCollector.props(Some(new Reporter {
     def report(metric: Metric): Unit = receivedMetrics = metric :: receivedMetrics
-  }))
+  })))
 
 }
 

--- a/core/src/test/scala/kanaloa/dispatcher/queue/TestUtils.scala
+++ b/core/src/test/scala/kanaloa/dispatcher/queue/TestUtils.scala
@@ -33,7 +33,7 @@ object TestUtils {
     def defaultProcessorProps(
       queue:            QueueRef,
       settings:         ProcessingWorkerPoolSettings = ProcessingWorkerPoolSettings(startingPoolSize = 1),
-      metricsCollector: ActorRef                     = MetricsCollector(None)
+      metricsCollector: ActorRef                     = system.actorOf(MetricsCollector.props(None))
     ) = QueueProcessor.default(queue, backend, settings, metricsCollector)(resultChecker)
   }
 }


### PR DESCRIPTION
… dependency fixes #161
Prior to this change, the factory method of dispatcher creates a new `StatsDClient` for each dispatcher, which might open excessive UDP connections. Also the `MetricsCollector` though a critical component of Dispatcher is created outside and passed in. With this change, the dispatcher can control the life cycle of this component and supervise it. 
