### PR TITLE
making all config hyphen cased / upgraded akka

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ An example of a `my-dispatcher`
 kanaloa {
   dispatchers {
     my-service1 {
-      workerPool {
-       startingPoolSize = 8
+      worker-pool {
+       starting-pool-size = 8
       }
-      workTimeout = 3s
+      work-timeout = 3s
     }
   }
 }

--- a/cluster/src/multi-jvm/scala/kanaloa.reactive.dispatcher/ClusterAwareBackendSpec.scala
+++ b/cluster/src/multi-jvm/scala/kanaloa.reactive.dispatcher/ClusterAwareBackendSpec.scala
@@ -32,7 +32,7 @@ object ClusterAwareBackendSpec extends ClusterConfig {
     """
       |kanaloa {
       |  default-dispatcher {
-      |    workerPool.startingPoolSize = 2
+      |    worker-pool.starting-pool-size = 2
       |  }
       |}
     """.stripMargin)

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -2,77 +2,77 @@ kanaloa {
 
   #Default settings for all dispatchers
   default-dispatcher {
-    workTimeout = 1m
+    work-timeout = 1m
 
     # When displaying messages in logs, this is the length to truncate at.
-    lengthOfDisplayForMessage = 200
+    length-of-display-for-message = 200
 
     # how often dispatcher makes adjustment accordingly
-    updateInterval = 1s
+    update-interval = 1s
 
     # When backend fails the work, the dispatcher can retry it for this many times.
     workRetry = 0
 
-    workerPool {
+    worker-pool {
 
       # Starting number of workers
-      startingPoolSize = 30
+      starting-pool-size = 30
 
       # Minimum number of workers
-      minPoolSize = 1
+      min-pool-size = 1
 
       # Maximum number of workers
-      maxPoolSize = 400
+      max-pool-size = 400
 
       # check if worker pool is in a healthy state every such interval.
-      healthCheckInterval = 5s
+      health-check-interval = 5s
 
       # whether or not log failures when retrieving routee
-      logRouteeRetrievalError = true
+      log-routee-retrieval-error = true
 
       # whether or not to shutdown the whole dispatcher when all workers died
-      shutdownOnAllWorkerDeath = false
+      shutdown-on-all-worker-death = false
 
       # default timeout for shutingdown
-      defaultShutdownTimeout = 30s
+      default-shutdown-timeout = 30s
     }
 
-    circuitBreaker {
+    circuit-breaker {
       enabled = on
 
       # Open duration per timeout, e.g. if the value is 10s and
       # there are 3 consecutive timeouts, the circuit breaker will be open for 30 seconds
       # if afterwards it gets another timeout, it will be open for another 40 seconds
-      openDurationBase = 10s
+      open-duration-base = 10s
 
       # CircuitBreaker opens for a worker when it sees consecutive timeouts at or above this threshold
-      timeoutCountThreshold = 3
+      timeout-count-threshold = 3
     }
 
     # Only applicable for pushing dispatcher
     # Algorithm used is PIE (Proportional Integral controller Enhanced)
     # see https://www.ietf.org/mail-archive/web/iccrg/current/pdfB57AZSheOH.pdf
-    backPressure {
+    back-pressure {
       enabled = on
 
       # Roughly speaking it's the threshold above which backpressure will start to drop requests
-      referenceDelay = 30s
+      reference-delay = 30s
 
       # The factor of which the dropping probably is effect by difference between estimated delay and
-      # referenceDelay. E.g. if the estimated delay is 11 seconds, and the reference delay is 10 seconds,
+      # reference-delay. E.g. if the estimated delay is 11 seconds, and the reference delay is 10 seconds,
       # the probability will increase by ((11 - 10) / 10) * 0.2 = 2%, this is will be applied every
-      # updateInterval
-      delayFactorBase = 0.2
+      # update-interval
+      delay-factor-base = 0.2
 
       # The factor of which the dropping probably is effect by difference between estimated delay and
       # last delay. E.g. if the estimated delay is 11 seconds, the last delay is 12 seconds and
       # the reference delay is 10 seconds, then probability will decrease by
       # ((12 - 11) / 10) * 0.1 = 1%, this is will be applied every
-      # updateInterval
-      delayTrendFactorBase = 0.1
+      # update-interval
+      delay-trend-factor-base = 0.1
 
       # Duration of unregulated high volumn traffic allowed
-      durationOfBurstAllowed = 30s
+      duration-of-burst-allowed = 30s
 
       # The weight of the latest metric over old metrics when collecting
       # performance metrics.
@@ -81,7 +81,7 @@ kanaloa {
       # Given a weight of 0.3, the metrics
       # representing pool size 5 will be 6 * 0.3 + 10 * 0.7, i.e. 8.8 messages per millis
       # Obviously, this number should be between 0 and 1.
-      weightOfLatestMetric = 0.2
+      weight-of-latest-metric = 0.2
     }
 
     # It automatically adjust the size of work pool (and thus the concurrency)
@@ -112,29 +112,29 @@ kanaloa {
 
       # The probability of ramping down when all workers are busy
       # during exploration.
-      chanceOfScalingDownWhenFull = 0.3
+      chance-of-scaling-down-when-full = 0.3
 
       # Interval between each pool size adjustment attempt
       # This interval must be at least as long as the update interval
-      resizeInterval = ${kanaloa.default-dispatcher.updateInterval}
+      resize-interval = ${kanaloa.default-dispatcher.update-interval}
 
       # If the workers have not been fully utilized (i.e. all workers are busy) for such length,
       # the autothrottle will downsize the pool.
-      downsizeAfterUnderUtilization = 72h
+      downsize-after-under-utilization = 72h
 
       # When optimizing, the autothrottler only considers the sizes adjacent to the
       # current size. This number indicates how many adjacent sizes, at least, per side to consider .
-      optimizationMinRange = 6
+      optimization-min-range = 6
 
       # When optimizing, the autothrottler only considers the sizes adjacent to the
       # current size. This number indicates the ratio between the number of adjacent sizes per side to current size.
       # E.g. 0.3 means that when pool size is at 100, the optimization will look at all pool sizes from 70-130 for
       # finding an optimal one to move towards to.
-      optimizationRangeRatio = 0.3
+      optimization-range-ratio = 0.3
 
       # The maximum pool size change during
       # exploration. for example, 5 means that the change will be within +- 5
-      maxExploreStepSize = 5
+      max-explore-step-size = 5
 
       # When downsizing after a long streak of underutilization, the autothrottler
       # will downsize the pool to the highest utiliziation multiplied by a
@@ -142,10 +142,10 @@ kanaloa {
       # in comparison to the highest utilization.
       # E.g. if the highest utilization is 10, and the downsize ratio
       # is 0.8, the pool will be downsized to 8
-      downsizeRatio = 0.8
+      downsize-ratio = 0.8
 
       # Probability of doing an exploration v.s. optimization.
-      explorationRatio = 0.4
+      exploration-ratio = 0.4
 
       # The weight of the latest metric over old metrics when collecting
       # performance metrics.
@@ -154,7 +154,7 @@ kanaloa {
       # message at pool size 5. Given a weight of 0.3, the metrics
       # representing pool size 5 will be 6 * 0.3 + 10 * 0.7, i.e. 8.8 millis
       # Obviously, this number should be between 0 and 1.
-      weightOfLatestMetric = 0.2
+      weight-of-latest-metric = 0.2
 
       # When evaluating performance of a pool size, the weightOfLatency determines
       # how much weight on latency v.s. throughput. The score of a particular pool size is
@@ -162,9 +162,9 @@ kanaloa {
       # ```
       # weightOfLatency * normalizedLatency + (1 - weightOfLatency) * normalizedThroughput
       # ```
-      # E.g. a weightOfLatency = 0.1 means that
+      # E.g. a weight-of-latency = 0.1 means that
       # a 10% improvement on latency has the same weight as a 2% improvement of throughput
-      weightOfLatency = 0.2
+      weight-of-latency = 0.2
     }
 
     # Metrics report configuration
@@ -183,22 +183,22 @@ kanaloa {
 
   #Default settings for pulling dispatchers
   default-pulling-dispatcher {
-    workerPool {
-      shutdownOnAllWorkerDeath = true
+    worker-pool {
+      shutdown-on-all-worker-death = true
     }
 
     # for pulling timeout might mean work lost, so it should be more careful.
-    circuitBreaker {
-      openDurationBase = 30s
-      timeoutCountThreshold = 1
+    circuit-breaker {
+      open-duration-base = 30s
+      timeout-count-threshold = 1
     }
 
-    backPressure {
+    back-pressure {
       enabled = off
     }
 
     autothrottle {
-      downsizeAfterUnderUtilization = 30s
+      downsize-after-under-utilization = 30s
     }
   }
 
@@ -208,13 +208,13 @@ kanaloa {
   #   port = 8125
   #
   #   # If true, multiple stats will be sent in a single UDP packet
-  #   multiMetrics = true
+  #   multi-metrics = true
   #
   #   #If multiMetrics is true, this is the max buffer size before sending the UDP packet
-  #   packetBufferSize = 1024
+  #   packet-buffer-size = 1024
   #
   #   # Default sample rate to use for metrics, if unspecified
-  #   defaultSampleRate = 1.0
+  #   default-sample-rate = 1.0
   #
   # }
 
@@ -225,9 +225,9 @@ kanaloa {
 
   # Here is an exaample
   #  example {
-  #    workTimeout = 3s
-  #    circuitBreaker {
-  #      errorRateThreshold = 0.7
+  #    work-timeout = 3s
+  #    circuit-breaker {
+  #      timeout-count-threshold = 1
   #    }
   #  }
 

--- a/core/src/main/scala/kanaloa/dispatcher/Dispatcher.scala
+++ b/core/src/main/scala/kanaloa/dispatcher/Dispatcher.scala
@@ -12,6 +12,7 @@ import kanaloa.dispatcher.queue.Queue.{Enqueue, EnqueueRejected}
 import kanaloa.dispatcher.queue._
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+import net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
 import net.ceedubs.ficus.readers.ValueReader
 
 import scala.concurrent.duration._
@@ -109,8 +110,8 @@ object Dispatcher {
   private def toDispatcherSettings(config: Config): Dispatcher.Settings = {
     val settings = config.atPath("root").as[Dispatcher.Settings]("root")
     settings.copy(
-      regulator = readComponent[Regulator.Settings]("backPressure", config),
-      circuitBreaker = readComponent[CircuitBreakerSettings]("circuitBreaker", config),
+      regulator = readComponent[Regulator.Settings]("back-pressure", config),
+      circuitBreaker = readComponent[CircuitBreakerSettings]("circuit-breaker", config),
       autothrottle = readComponent[AutothrottleSettings]("autothrottle", config)
     )
   }

--- a/core/src/main/scala/kanaloa/dispatcher/metrics/Reporter.scala
+++ b/core/src/main/scala/kanaloa/dispatcher/metrics/Reporter.scala
@@ -2,6 +2,7 @@ package kanaloa.dispatcher.metrics
 
 import akka.actor.ActorSystem
 import com.typesafe.config.{ConfigFactory, Config}
+import net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
 
 trait Reporter {
   def report(metric: Metric): Unit

--- a/core/src/main/scala/kanaloa/dispatcher/metrics/StatsDClient.scala
+++ b/core/src/main/scala/kanaloa/dispatcher/metrics/StatsDClient.scala
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory
 import StatsDClient._
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+import net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
 
 /**
  * Client for sending stats to StatsD uses Akka to manage concurrency

--- a/core/src/test/scala/kanaloa/dispatcher/DispatcherSpec.scala
+++ b/core/src/test/scala/kanaloa/dispatcher/DispatcherSpec.scala
@@ -77,7 +77,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
           iterator,
           backendProb.ref,
           Some(resultProbe.ref),
-          ConfigFactory.parseString("kanaloa.default-dispatcher.workerPool.startingPoolSize = 20")
+          ConfigFactory.parseString("kanaloa.default-dispatcher.workerPool.starting-pool-size = 20")
         )(ResultChecker.complacent)
       )
 
@@ -203,8 +203,8 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
         ConfigFactory.parseString(
           """
             |kanaloa.default-dispatcher {
-            |  updateInterval = 300s
-            |  circuitBreaker.enabled = off
+            |  update-interval = 300s
+            |  circuit-breaker.enabled = off
             |  autothrottle.enabled = off
             |}""".stripMargin
         ) //make sure regulator doesn't interfere
@@ -232,10 +232,10 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
         ConfigFactory.parseString(
           """
             |kanaloa.default-dispatcher {
-            |  updateInterval = 10ms
-            |  backPressure {
-            |    durationOfBurstAllowed = 10ms
-            |    referenceDelay = 2s
+            |  update-interval = 10ms
+            |  back-pressure {
+            |    duration-of-burst-allowed = 10ms
+            |    reference-delay = 2s
             |  }
             |}""".stripMargin
         )
@@ -258,10 +258,10 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
         ConfigFactory.parseString(
           """
             |kanaloa.default-dispatcher {
-            |  updateInterval = 50ms
-            |  backPressure {
-            |    durationOfBurstAllowed = 30ms
-            |    referenceDelay = 1s
+            |  update-interval = 50ms
+            |  back-pressure {
+            |    duration-of-burst-allowed = 30ms
+            |    reference-delay = 1s
             |  }
             |}""".stripMargin
         )
@@ -304,7 +304,7 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
         """
             kanaloa {
               default-dispatcher {
-                workRetry = 27
+                work-retry = 27
               }
               dispatchers {
 
@@ -321,11 +321,11 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
         """
             kanaloa {
               default-dispatcher {
-                workRetry = 29
+                work-retry = 29
               }
               dispatchers {
                 example {
-                  workTimeout = 1m
+                  work-timeout = 1m
                 }
               }
 
@@ -354,13 +354,13 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
       settings.autothrottle shouldBe None
     }
 
-    "turn off circuitBreaker if set to off" in {
+    "turn off circuit-breaker if set to off" in {
       val cfgStr =
         """
             kanaloa {
               dispatchers {
                 example {
-                  circuitBreaker {
+                  circuit-breaker {
                     enabled = off
                   }
                 }
@@ -377,8 +377,8 @@ class DispatcherSpec extends SpecWithActorSystem with OptionValues {
             kanaloa {
               dispatchers {
                 example {
-                  circuitBreaker {
-                    timeoutCountThreshold = 0.5
+                  circuit-breaker {
+                    timeout-count-threshold = 0.5
                   }
                 }
               }

--- a/core/src/test/scala/kanaloa/dispatcher/IntegrationTests.scala
+++ b/core/src/test/scala/kanaloa/dispatcher/IntegrationTests.scala
@@ -78,8 +78,8 @@ class PushingDispatcherIntegration extends IntegrationSpec {
       ConfigFactory.parseString(
         s"""
           kanaloa.dispatchers.test-pushing {
-            workerPool {
-              startingPoolSize = 8
+            worker-pool {
+              starting-pool-size = 8
             }
           }
         """
@@ -110,16 +110,16 @@ class MinimalPushingDispatcherIntegration extends IntegrationSpec {
       ConfigFactory.parseString(
         s"""
           kanaloa.dispatchers.test-pushing {
-            workerPool {
-              startingPoolSize = 8
+            worker-pool {
+              starting-pool-size = 8
             }
             autothrottle {
               enabled = off
             }
-            backPressure {
+            back-pressure {
               enabled = off
             }
-            circuitBreaker {
+            circuit-breaker {
               enabled = off
             }
           }
@@ -153,8 +153,8 @@ class PullingDispatcherIntegration extends IntegrationSpec {
       ConfigFactory.parseString(
         s"""
           kanaloa.dispatchers.test-pulling {
-            workerPool {
-              startingPoolSize = 8
+            worker-pool {
+              starting-pool-size = 8
             }
           }
         """
@@ -184,11 +184,11 @@ class PullingDispatcherSanityCheckIntegration extends IntegrationSpec {
       ConfigFactory.parseString(
         s"""
           kanaloa.dispatchers.test-pulling {
-            updateInterval = 100ms
-            workerPool {
-              startingPoolSize = 30
-              minPoolSize = 30
-              shutdownOnAllWorkerDeath = false
+            update-interval = 100ms
+            worker-pool {
+              starting-pool-size = 30
+              min-pool-size = 30
+              shutdown-on-all-worker-death = false
             }
             $metricsConfig
           }
@@ -237,22 +237,22 @@ class AutothrottleWithPushingIntegration extends IntegrationSpec {
         ConfigFactory.parseString(
           s"""
           kanaloa.dispatchers.test-pushing {
-            updateInterval = 100ms
-            workerPool {
-              startingPoolSize = 3
-              minPoolSize = 1
+            update-interval = 100ms
+            worker-pool {
+              starting-pool-size = 3
+              min-pool-size = 1
             }
-            backPressure {
+            back-pressure {
               maxBufferSize = 60000
               thresholdForExpectedWaitTime = 1h
               maxHistoryLength = 3s
             }
             autothrottle {
-              chanceOfScalingDownWhenFull = 0.3
-              resizeInterval = 200ms
-              weightOfLatency = 0.1
-              explorationRatio = 0.5
-              maxExploreStepSize = 1
+              chance-of-scaling-down-when-full = 0.3
+              resize-interval = 200ms
+              weight-of-latency = 0.1
+              exploration-ratio = 0.5
+              max-explore-step-size = 1
             }
             $metricsConfig
           }
@@ -301,20 +301,20 @@ class AutothrottleWithPullingIntegration extends IntegrationSpec {
       ConfigFactory.parseString(
         s"""
           kanaloa.dispatchers.test-pulling {
-            updateInterval = 100ms
-            workerPool {
-              startingPoolSize = 3
-              minPoolSize = 1
+            update-interval = 100ms
+            worker-pool {
+              starting-pool-size = 3
+              min-pool-size = 1
             }
-            backPressure {
+            back-pressure {
               maxBufferSize = 60000
               thresholdForExpectedWaitTime = 1h
               maxHistoryLength = 3s
             }
             autothrottle {
-              chanceOfScalingDownWhenFull = 0.1
-              resizeInterval = 100ms
-              downsizeAfterUnderUtilization = 72h
+              chance-of-scaling-down-when-full = 0.1
+              resize-interval = 100ms
+              downsize-after-under-utilization = 72h
             }
             $metricsConfig
           }
@@ -364,14 +364,14 @@ class AutothrottleDownSizeWithSparseTrafficIntegration extends IntegrationSpec {
       ConfigFactory.parseString(
         """
           kanaloa.dispatchers.test-pushing {
-            updateInterval = 100ms
-            workerPool {
-              startingPoolSize = 10
-              minPoolSize = 2
+            update-interval = 100ms
+            worker-pool {
+              starting-pool-size = 10
+              min-pool-size = 2
             }
             autothrottle {
-              resizeInterval = 10ms
-              downsizeAfterUnderUtilization = 100ms
+              resize-interval = 10ms
+              downsize-after-under-utilization = 100ms
             }
           }
         """

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akka = "2.4.8"
+    val akka = "2.4.11"
   }
 
   val akka = Seq(
@@ -19,7 +19,7 @@ object Dependencies {
   )
 
   val akkaHttp = Seq(
-    "com.typesafe.akka" %% "akka-http-experimental" % Versions.akka
+    "com.typesafe.akka" %% "akka-http-experimental" % "2.4.11"
   )
 
   val akkaThrottler = Seq(
@@ -27,8 +27,8 @@ object Dependencies {
   )
 
   val gatling = Seq(
-    "io.gatling.highcharts" % "gatling-charts-highcharts" % "2.2.3-SNAPSHOT" % Test,
-    "io.gatling"            % "gatling-test-framework"    % "2.2.3-SNAPSHOT" % Test
+    "io.gatling.highcharts" % "gatling-charts-highcharts" % "2.2.3" % Test,
+    "io.gatling"            % "gatling-test-framework"    % "2.2.3" % Test
   )
 
   val (test, integration) = {
@@ -41,7 +41,7 @@ object Dependencies {
   }
 
   val config = Seq(
-    "com.iheart" %% "ficus" % "1.2.6"
+    "com.iheart" %% "ficus" % "1.3.3"
   )
 
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/stress/frontend/src/main/resources/frontend.conf
+++ b/stress/frontend/src/main/resources/frontend.conf
@@ -4,22 +4,21 @@ frontend-timeout = 30s
 kanaloa {
 
   default-dispatcher {
-    workTimeout = 1m
+    work-timeout = 1m
 
-    updateInterval = 200ms
+    update-interval = 200ms
 
-    workerPool {
-      startingPoolSize = 30
+    worker-pool {
+      starting-pool-size = 30
     }
 
     autothrottle {
-      numOfAdjacentSizesToConsiderDuringOptimization = 18
-      chanceOfScalingDownWhenFull = 0.3
+      chance-of-scaling-down-when-full = 0.3
     }
 
-    backPressure {
-      referenceDelay = 1s
-      durationOfBurstAllowed = 10s
+    back-pressure {
+      reference-delay = 1s
+      duration-of-burst-allowed = 10s
     }
 
   }

--- a/stress/frontend/src/main/scala/kanaloa/stress/frontend/HttpService.scala
+++ b/stress/frontend/src/main/scala/kanaloa/stress/frontend/HttpService.scala
@@ -77,9 +77,9 @@ class HttpService(inCluster: Boolean, maxThroughputRPS: Option[Int] = None) {
     ConfigFactory.parseString(
       """
         |kanaloa.default-dispatcher {
-        |  workerPool {
-        |    startingPoolSize = 1000
-        |    maxPoolSize = 3000
+        |  worker-pool {
+        |    starting-pool-size = 1000
+        |    max-pool-size = 3000
         |  }
         |}
       """.stripMargin


### PR DESCRIPTION
Fixes #183 
switch from camelcase config keys to hyphen cased config keys thanks the newly added support in ficus. 